### PR TITLE
fix sidebar for `DistillationCallback`

### DIFF
--- a/nbs/_quarto.yml
+++ b/nbs/_quarto.yml
@@ -87,7 +87,7 @@ website:
         - prune/prune_callback.ipynb
       - section: Distill
         contents:
-        - distill/distill_callback.ipynb
+        - distill/distillation_callback.ipynb
       - section: Quantize
         contents:
         - quantize/quantizer.ipynb


### PR DESCRIPTION
This PR fixes the link for distillation callback.

From
![image](https://github.com/user-attachments/assets/76c7e2b9-d655-498e-985d-5eda3f69ae92)

To 
![image](https://github.com/user-attachments/assets/c4ee455c-f0a2-4769-8abd-098804391492)

cc @nathanhubens 
