### PR TITLE
Add QAT + Knowledge Distillation tutorial

### DIFF
--- a/nbs/tutorials/quantize/qat_distill.ipynb
+++ b/nbs/tutorials/quantize/qat_distill.ipynb
@@ -1,0 +1,101 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "id": "frontmatter",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: QAT + Knowledge Distillation\n",
+    "description: Combine quantization-aware training with knowledge distillation for best INT8 accuracy\n",
+    "output-file: tutorial.qat_distill.html\n",
+    "skip_showdoc: true\n",
+    "skip_exec: true\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "overview",
+   "metadata": {},
+   "source": "## Overview\n\nQuantization-Aware Training (QAT) simulates INT8 quantization during training, letting the model learn to be robust to reduced precision. Adding **Knowledge Distillation** on top provides a teacher's soft labels to guide the student through the quantization noise — recovering 80-95% of accuracy loss.\n\n### Why combine them?\n\n| Approach | Accuracy Recovery | Training Cost |\n|----------|------------------|---------------|\n| Post-training quantization (PTQ) | 50-80% | None |\n| QAT alone | 70-90% | Full training |\n| **QAT + Distillation** | **80-95%** | Full training + teacher forward pass |\n\n### How it works\n\nBoth are fastai callbacks — just pass them together:\n\n```\nlearn.fit(epochs, cbs=[QuantizeCallback(...), KnowledgeDistillationCallback(...)])\n```\n\nThe QAT callback handles fake quantization nodes. The distillation callback blends the teacher's soft labels into the loss. They don't interfere with each other."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "setup",
+   "metadata": {},
+   "outputs": [],
+   "source": "from fastai.vision.all import *\nfrom fasterai.quantize.quantize_callback import QuantizeCallback\nfrom fasterai.distill.distillation_callback import KnowledgeDistillationCallback\nfrom fasterai.distill.losses import DecoupledKD, SoftTarget\nfrom copy import deepcopy\n\n# Data\npath = untar_data(URLs.PETS)\nfiles = get_image_files(path/\"images\")\ndef label_func(f): return f[0].isupper()\ndls = ImageDataLoaders.from_name_func(path, files, label_func, item_tfms=Resize(64))"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "train",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Step 1: Train a teacher model\nlearn = vision_learner(dls, resnet18, metrics=accuracy)\nlearn.unfreeze()\nlearn.fit(3)\n\n# Save the teacher (full precision, best accuracy)\nteacher = deepcopy(learn.model).eval()"
+  },
+  {
+   "cell_type": "markdown",
+   "execution_count": null,
+   "id": "qat-only",
+   "metadata": {},
+   "outputs": [],
+   "source": "## Approach 1: QAT Only (Baseline)\n\nFirst, let's see what QAT alone gives us:"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0y7v3rqdr9ob",
+   "metadata": {},
+   "outputs": [],
+   "source": "# QAT only — no distillation\nlearn_qat = vision_learner(dls, resnet18, metrics=accuracy)\nlearn_qat.unfreeze()\nlearn_qat.fit(3, cbs=[\n    QuantizeCallback(backend='x86'),\n])"
+  },
+  {
+   "cell_type": "markdown",
+   "execution_count": null,
+   "id": "qat-kd",
+   "metadata": {},
+   "outputs": [],
+   "source": "## Approach 2: QAT + Knowledge Distillation\n\nNow add the teacher — the distillation loss helps the student navigate the quantization noise:"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7x1x9eqjd6o",
+   "metadata": {},
+   "outputs": [],
+   "source": "# QAT + Knowledge Distillation — teacher guides the quantized student\nlearn_qat_kd = vision_learner(dls, resnet18, metrics=accuracy)\nlearn_qat_kd.unfreeze()\nlearn_qat_kd.fit(3, cbs=[\n    QuantizeCallback(backend='x86'),\n    KnowledgeDistillationCallback(teacher=teacher, loss=DecoupledKD, weight=0.5),\n])"
+  },
+  {
+   "cell_type": "markdown",
+   "execution_count": null,
+   "id": "compare",
+   "metadata": {},
+   "outputs": [],
+   "source": "## Choosing a Loss Function\n\nDifferent distillation losses work well with QAT:\n\n| Loss | Type | Notes |\n|------|------|-------|\n| **SoftTarget** | Output | Simple, good default for QAT+KD |\n| **DecoupledKD** | Output | Better dark knowledge preservation |\n| **DecoupledKD** `normalize=True` | Output | NKD mode — best for many-class problems |\n\n```python\n# SoftTarget — simplest option\nKnowledgeDistillationCallback(teacher=teacher, loss=SoftTarget, weight=0.5)\n\n# DecoupledKD with NKD — best accuracy\nfrom functools import partial\nKnowledgeDistillationCallback(teacher=teacher, loss=partial(DecoupledKD, normalize=True), weight=0.5)\n```\n\nThe `weight` parameter (default 0.5) controls the balance between the standard loss and the distillation loss. Higher values lean more on the teacher."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tips",
+   "metadata": {},
+   "source": "## Tips\n\n- **Use the same architecture** for teacher and student for best results — the teacher is the full-precision version of the same model\n- **Lower learning rate** — QAT benefits from smaller LR since the fake quantization adds noise. Try `1e-4` to `1e-3`\n- **More epochs** — QAT typically needs more epochs than standard training to converge through the quantization noise\n- **Teacher stays frozen** — the teacher is always in `eval()` mode, no gradients flow through it\n- **Convert after training** — after QAT + KD training, convert to real INT8: `Quantizer(backend='x86', method='qat').quantize(learn.model, dls.valid)`"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "summary",
+   "metadata": {},
+   "source": "---\n\n## Summary\n\n| Component | Role |\n|-----------|------|\n| `QuantizeCallback(backend)` | Inserts fake quantization nodes during training |\n| `KnowledgeDistillationCallback(teacher, loss)` | Blends teacher soft labels into training loss |\n| Both together | QAT accuracy + distillation recovery — best INT8 results |\n\nThe key insight: both are standard fastai callbacks — just pass them together in `cbs=[...]`. No special wiring needed.\n\n---\n\n## See Also\n\n- [Quantization Tutorial](tutorial.quantize.html) - PTQ and torchao quantization\n- [QAT Callback](tutorial.quantize_callback.html) - QAT details\n- [Distillation Tutorial](../distill/distill_callback.html) - Distillation losses and setup"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Tutorial showing how to combine QAT and Knowledge Distillation for best INT8 accuracy recovery. No code changes — both callbacks already compose natively via fastai.

## Content

- Why combine QAT + KD (accuracy recovery comparison table)
- Step-by-step: train teacher → QAT-only baseline → QAT + KD
- Loss function selection guide (SoftTarget, DecoupledKD, NKD)
- Practical tips (LR, epochs, conversion)