### PR TITLE
docs: trim ecosystem overview to the open peer packages

### DIFF
--- a/nbs/overview.ipynb
+++ b/nbs/overview.ipynb
@@ -265,7 +265,24 @@
    "cell_type": "markdown",
    "id": "c5xvp6sdy6d",
    "metadata": {},
-   "source": "## The FasterAI Ecosystem\n\nfasterai is part of a family of libraries designed to make neural network optimization accessible:\n\n| Package | Purpose | When to Use |\n|---------|---------|-------------|\n| **fasterai** | Compression techniques | Pruning, sparsification, distillation, quantization during training |\n| **fasterbench** | Benchmarking | Measuring model size, speed, memory, compute, and energy |\n| **fasterlatency** | Latency prediction | Hardware-aware neural architecture search |\n| **fasterrecipes** | High-level workflows | Quick compression with sensible defaults |\n\n### Typical Workflow\n\n1. **Benchmark** your model with `fasterbench` to identify bottlenecks\n2. **Compress** using `fasterai` techniques (pruning, distillation, quantization)\n3. **Validate** compression impact with `fasterbench`\n4. **Deploy** the optimized model\n\nOr use `fasterrecipes` for one-line compression with sensible defaults!"
+   "source": [
+    "## The FasterAI Ecosystem\n",
+    "\n",
+    "fasterai is part of a family of libraries designed to make neural network optimization accessible:\n",
+    "\n",
+    "| Package | Purpose | When to Use |\n",
+    "|---------|---------|-------------|\n",
+    "| **fasterai** | Compression techniques | Pruning, sparsification, distillation, quantization during training |\n",
+    "| **fasterbench** | Benchmarking | Measuring model size, speed, memory, compute, and energy |\n",
+    "| **fasterlatency** | Latency prediction | Hardware-aware neural architecture search |\n",
+    "\n",
+    "### Typical Workflow\n",
+    "\n",
+    "1. **Benchmark** your model with `fasterbench` to identify bottlenecks\n",
+    "2. **Compress** using `fasterai` techniques (pruning, distillation, quantization)\n",
+    "3. **Validate** compression impact with `fasterbench`\n",
+    "4. **Deploy** the optimized model"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Trims the **FasterAI Ecosystem** table in `overview.ipynb` to fasterai's open peer packages (fasterai, fasterbench, fasterlatency) and drops the closing one-line pointer to a downstream workflow package.

Docs-only, markdown cell — no code or export impact.
