### PR TITLE
docs(tutorials): quantize_callback and onnx_export on the pt2e/QDQ path; prune_callback on fractions

### DIFF
--- a/nbs/tutorials/export/onnx_export.ipynb
+++ b/nbs/tutorials/export/onnx_export.ipynb
@@ -2,44 +2,49 @@
  "cells": [
   {
    "cell_type": "raw",
-   "id": "frontmatter",
+   "id": "fm",
    "metadata": {},
    "source": [
     "---\n",
-    "description: Export compressed models to ONNX for deployment\n",
+    "title: ONNX Export\n",
+    "description: Sparsify, fold, export and check a model in ONNX — float, then INT8\n",
     "output-file: tutorial.onnx_export.html\n",
-    "title: ONNX Export Tutorial\n",
     "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "onnx-no-outputs",
-   "metadata": {},
-   "source": [
-    ":::{.callout-warning}\n",
-    "## This page shows no outputs\n",
-    "\n",
-    "The cells below were not executed in this build: the data-loading cell failed with a CUDA out-of-memory error on the machine that produced the notebook, and no cell after it produced an output. Nothing on this page is a measurement — the sizes, speed-ups and verification results it prints are whatever your own run produces, and none of them is reported here.\n",
-    ":::"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "imports",
+   "id": "setup",
    "metadata": {},
    "outputs": [],
    "source": [
     "#| include: false\n",
-    "from fastai.vision.all import *\n",
-    "from fasterai.sparse.all import *\n",
-    "from fasterai.misc.all import *\n",
-    "from fasterai.export.all import *\n",
+    "import logging, tempfile, warnings\n",
+    "from itertools import islice\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import onnx\n",
+    "import onnxruntime\n",
     "import torch\n",
-    "import torch.nn as nn"
+    "import torch.nn as nn\n",
+    "from fastai.vision.all import *\n",
+    "from onnx import numpy_helper\n",
+    "from torchvision.models import resnet18, ResNet18_Weights\n",
+    "\n",
+    "from fasterai.core.all import quant_spec\n",
+    "from fasterai.export.all import ONNXModel, export_onnx, export_qdq, qdq_stats, verify_onnx, verify_qdq\n",
+    "from fasterai.misc.all import BN_Folder\n",
+    "from fasterai.quantize.all import Quantizer\n",
+    "from fasterai.sparse.all import SparsifyCallback, large_final, one_cycle\n",
+    "\n",
+    "warnings.filterwarnings('ignore', message='.*erase_node.*')           # torch.fx, during the pt2e convert\n",
+    "warnings.filterwarnings('ignore', message='.*export_for_training.*')  # torch.export deprecation notice\n",
+    "warnings.filterwarnings('error', message='.*looks like a percent.*')  # a percent literal aborts this page\n",
+    "logging.getLogger('torch.onnx').setLevel(logging.ERROR)               # exporter schema notes\n",
+    "TMP = Path(tempfile.mkdtemp())                                        # nothing is written to the repo"
    ]
   },
   {
@@ -49,71 +54,74 @@
    "source": [
     "## Overview\n",
     "\n",
-    "After compressing a model with fasterai, you'll want to **deploy** it. ONNX (Open Neural Network Exchange) is the standard format for deploying models across different platforms and runtimes.\n",
-    "\n",
-    "### Why Export to ONNX?\n",
-    "\n",
-    "| Benefit | Description |\n",
-    "|---------|-------------|\n",
-    "| **Portability** | Run on any platform: servers, mobile, edge devices, browsers |\n",
-    "| **Performance** | ONNX Runtime is highly optimized for inference |\n",
-    "| **Quantization** | Apply additional INT8 quantization during export |\n",
-    "| **No Python needed** | Deploy without Python dependencies |\n",
-    "\n",
-    "### The Deployment Pipeline\n",
-    "\n",
-    "```\n",
-    "Train → Compress (prune/sparsify/quantize) → Fold BN → Export ONNX → Deploy\n",
-    "```\n",
-    "\n",
-    "This tutorial walks through the complete pipeline."
+    "One path, run end to end: fine-tune a ResNet-18, sparsify it, fold its batch norms, export it to\n",
+    "ONNX and check the file that comes out. Then the same model in INT8, scored against the float file."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "setup-header",
+   "id": "train-md",
    "metadata": {},
    "source": [
-    "## 1. Setup and Training\n",
+    "## 1. Train, then sparsify\n",
     "\n",
-    "First, let's train a model that we'll later compress and export."
+    "Oxford-IIIT Pet, two classes, 64px. Three epochs of fine-tuning, then two more under\n",
+    "`SparsifyCallback` with `sparsity=0.5`, a fraction: half the weights of every convolution end up\n",
+    "zero."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "setup-data",
+   "id": "train",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch 2.9.1+cu128 | onnx 1.17.0 | onnxruntime 1.24.1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0, 0.3779972493648529, 0.36142417788505554, 0.8552097678184509, '00:04']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1, 0.23007234930992126, 0.19752638041973114, 0.9194858074188232, '00:04']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2, 0.11908359825611115, 0.18409502506256104, 0.9336941838264465, '00:05']\n"
+     ]
+    }
+   ],
    "source": [
+    "print(\"torch\", torch.__version__, \"| onnx\", onnx.__version__,\n",
+    "      \"| onnxruntime\", onnxruntime.__version__)\n",
+    "\n",
     "path = untar_data(URLs.PETS)\n",
     "files = get_image_files(path/\"images\")\n",
     "\n",
     "def label_func(f): return f[0].isupper()\n",
     "\n",
-    "dls = ImageDataLoaders.from_name_func(path, files, label_func, item_tfms=Resize(64))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "train-model",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "learn = vision_learner(dls, resnet18, metrics=accuracy)\n",
-    "learn.unfreeze()\n",
-    "learn.fit_one_cycle(3)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "compress-header",
-   "metadata": {},
-   "source": [
-    "## 2. Compress the Model\n",
+    "dls = ImageDataLoaders.from_name_func(path, files, label_func, item_tfms=Resize(64), bs=64)\n",
     "\n",
-    "Apply sparsification to reduce model size. You could also use pruning, quantization, or any combination."
+    "torch.manual_seed(0)\n",
+    "net = resnet18(weights=ResNet18_Weights.DEFAULT)\n",
+    "net.fc = nn.Linear(512, 2)\n",
+    "\n",
+    "learn = Learner(dls, net, metrics=accuracy)\n",
+    "with learn.no_bar(): learn.fit_one_cycle(3, 1e-3)"
    ]
   },
   {
@@ -121,67 +129,335 @@
    "execution_count": null,
    "id": "sparsify",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsifying weight until a sparsity of 50.00%\n",
+      "Saving Weights at epoch 0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsity at the end of epoch 0: 36.57%\n",
+      "[0, 0.18205663561820984, 0.26363885402679443, 0.8883626461029053, '00:08']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsity at the end of epoch 1: 50.00%\n",
+      "[1, 0.12024571001529694, 0.17602984607219696, 0.934370756149292, '00:09']\n",
+      "Final Sparsity: 50.00%\n",
+      "\n",
+      "Sparsity Report:\n",
+      "--------------------------------------------------------------------------------\n",
+      "Layer                          Type            Params     Zeros      Sparsity  \n",
+      "--------------------------------------------------------------------------------\n",
+      "conv1                          Conv2d          9,408      4,702         49.98%\n",
+      "layer1.0.conv1                 Conv2d          36,864     18,430        49.99%\n",
+      "layer1.0.conv2                 Conv2d          36,864     18,430        49.99%\n",
+      "layer1.1.conv1                 Conv2d          36,864     18,430        49.99%\n",
+      "layer1.1.conv2                 Conv2d          36,864     18,430        49.99%\n",
+      "layer2.0.conv1                 Conv2d          73,728     36,862        50.00%\n",
+      "layer2.0.conv2                 Conv2d          147,456    73,725        50.00%\n",
+      "layer2.0.downsample.0          Conv2d          8,192      4,094         49.98%\n",
+      "layer2.1.conv1                 Conv2d          147,456    73,725        50.00%\n",
+      "layer2.1.conv2                 Conv2d          147,456    73,725        50.00%\n",
+      "layer3.0.conv1                 Conv2d          294,912    147,451       50.00%\n",
+      "layer3.0.conv2                 Conv2d          589,824    294,903       50.00%\n",
+      "layer3.0.downsample.0          Conv2d          32,768     16,382        49.99%\n",
+      "layer3.1.conv1                 Conv2d          589,824    294,903       50.00%\n",
+      "layer3.1.conv2                 Conv2d          589,824    294,903       50.00%\n",
+      "layer4.0.conv1                 Conv2d          1,179,648  589,808       50.00%\n",
+      "layer4.0.conv2                 Conv2d          2,359,296  1,179,618     50.00%\n",
+      "layer4.0.downsample.0          Conv2d          131,072    65,533        50.00%\n",
+      "layer4.1.conv1                 Conv2d          2,359,296  1,179,618     50.00%\n",
+      "layer4.1.conv2                 Conv2d          2,359,296  1,179,618     50.00%\n",
+      "--------------------------------------------------------------------------------\n",
+      "Overall                        all             11,166,912 5,583,290     50.00%\n"
+     ]
+    }
+   ],
    "source": [
-    "sp_cb = SparsifyCallback(sparsity=50, granularity='weight', context='local', criteria=large_final, schedule=one_cycle)\n",
-    "learn.fit_one_cycle(2, cbs=sp_cb)"
+    "sp_cb = SparsifyCallback(sparsity=0.5, granularity='weight', context='local',\n",
+    "                         criteria=large_final, schedule=one_cycle)\n",
+    "with learn.no_bar(): learn.fit_one_cycle(2, 1e-3, cbs=sp_cb)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "fold-header",
+   "id": "fold-md",
    "metadata": {},
    "source": [
-    "## 3. Fold BatchNorm Layers\n",
+    "## 2. Fold batch norm\n",
     "\n",
-    "Before export, fold batch normalization layers into convolutions for faster inference:"
+    "`BN_Folder` folds each `BatchNorm2d` into the convolution before it, leaving none in the model:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fold-bn",
+   "id": "fold",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 BatchNorm2d modules left\n"
+     ]
+    }
+   ],
    "source": [
-    "bn_folder = BN_Folder()\n",
-    "model = bn_folder.fold(learn.model)\n",
-    "model.eval();"
+    "model = BN_Folder().fold(learn.model)\n",
+    "model.eval().cpu()\n",
+    "\n",
+    "print(sum(1 for m in model.modules() if isinstance(m, nn.BatchNorm2d)), \"BatchNorm2d modules left\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "export-header",
+   "id": "batches-md",
    "metadata": {},
    "source": [
-    "## 4. Export to ONNX\n",
-    "\n",
-    "Now export the optimized model to ONNX format:"
+    "The batches the rest of the page reuses: four for calibration, and every full validation batch — a\n",
+    "captured graph runs one batch size, so the short last batch is dropped."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "basic-export",
+   "id": "batches",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 calibration batches | 23 validation batches | 1472 images\n"
+     ]
+    }
+   ],
    "source": [
-    "# Create example input (batch_size=1, channels=3, height=64, width=64)\n",
+    "BATCH = 64\n",
+    "\n",
+    "calibration_batches = [xb.cpu() for xb, _ in islice(dls.train, 4)]\n",
+    "valid_batches = [(xb.cpu(), yb.cpu()) for xb, yb in dls.valid if len(yb) == BATCH]\n",
+    "\n",
+    "print(len(calibration_batches), \"calibration batches |\", len(valid_batches), \"validation batches |\",\n",
+    "      sum(len(yb) for _, yb in valid_batches), \"images\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "export-md",
+   "metadata": {},
+   "source": [
+    "## 3. Export the float model\n",
+    "\n",
+    "`export_onnx` writes the file, `verify_onnx` compares its outputs against PyTorch's, `ONNXModel`\n",
+    "runs it through ONNX Runtime."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "export",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "model.onnx 44.7 MB\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "verify_onnx: True\n",
+      "ONNXModel output: (1, 2)\n"
+     ]
+    }
+   ],
+   "source": [
     "sample = torch.randn(1, 3, 64, 64)\n",
     "\n",
-    "# Export to ONNX\n",
-    "onnx_path = export_onnx(model.cpu(), sample, \"model.onnx\")\n",
-    "print(f\"Exported to: {onnx_path}\")"
+    "float_path = export_onnx(model, sample, TMP/\"model.onnx\")\n",
+    "print(float_path.name, f\"{float_path.stat().st_size / 1e6:.1f} MB\")\n",
+    "print(\"verify_onnx:\", verify_onnx(model, float_path, sample))\n",
+    "print(\"ONNXModel output:\", tuple(ONNXModel(float_path, device=\"cpu\")(sample).shape))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "verify-header",
+   "id": "postcond-md",
    "metadata": {},
    "source": [
-    "### Verify the Export\n",
+    "What counts is what the file carries, not what the pipeline intended, so read the zeros back out of\n",
+    "the exported convolution weights:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "postcond",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "20 Conv weight tensors: 5583290/11166912 zeros = 50.00%\n",
+      "declared opset: [('ai.onnx', 17)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "proto = onnx.load(str(float_path))\n",
+    "initializers = {i.name: i for i in proto.graph.initializer}\n",
+    "weights = [numpy_helper.to_array(initializers[n.input[1]])\n",
+    "           for n in proto.graph.node if n.op_type == \"Conv\" and n.input[1] in initializers]\n",
     "\n",
-    "Always verify that the ONNX model produces the same outputs as the PyTorch model:"
+    "zeros, total = sum(int((w == 0).sum()) for w in weights), sum(w.size for w in weights)\n",
+    "print(f\"{len(weights)} Conv weight tensors: {zeros}/{total} zeros = {zeros/total:.2%}\")\n",
+    "print(\"declared opset:\", [(o.domain or \"ai.onnx\", o.version) for o in proto.opset_import])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "int8-md",
+   "metadata": {},
+   "source": [
+    "## 4. The same model in INT8\n",
+    "\n",
+    "`Quantizer(backend='pt2e')` captures the model with `torch.export`, calibrates on those batches and\n",
+    "converts it to a symmetric INT8 graph. `export_qdq` writes it with the Q/DQ pairs intact;\n",
+    "`qdq_stats` counts what ended up in the file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "quantize",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'backend': 'pt2e', 'method': 'static', 'weight_bits': 8, 'act_bits': 8, 'qscheme': 'per_channel', 'symmetric': True, 'group_size': None, 'layer_bits': None, 'qdq_placement': 'per_op'}\n",
+      "W8A8 | exportable: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "qmodel = Quantizer(backend='pt2e').quantize(\n",
+    "    model, calibration_dl=calibration_batches, max_calibration_samples=256)\n",
+    "\n",
+    "spec = quant_spec(qmodel)\n",
+    "print(spec.as_dict())\n",
+    "print(spec.label, \"| exportable:\", spec.exports)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "export-qdq",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[torch.onnx] Obtain model graph for `GraphModule([...]` with `torch.export.export(..., strict=False)`...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[torch.onnx] Obtain model graph for `GraphModule([...]` with `torch.export.export(..., strict=False)`... ✅\n",
+      "[torch.onnx] Run decomposition...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[torch.onnx] Run decomposition... ✅\n",
+      "[torch.onnx] Translate the graph into ONNX...\n",
+      "[torch.onnx] Translate the graph into ONNX... ✅\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "model_int8.onnx 11.4 MB (3.9x smaller than the float file)\n",
+      "{'n_quantize': 33, 'n_dequantize': 54, 'n_per_channel': 21, 'n_nonzero_zero_point': 0, 'n_unquantized_conv_add': 0}\n",
+      "declared opset: [('ai.onnx', 18)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "qdq_path = export_qdq(qmodel, calibration_batches[0], TMP/\"model_int8.onnx\")\n",
+    "print(qdq_path.name, f\"{qdq_path.stat().st_size / 1e6:.1f} MB\",\n",
+    "      f\"({float_path.stat().st_size / qdq_path.stat().st_size:.1f}x smaller than the float file)\")\n",
+    "print(qdq_stats(qdq_path).as_dict())\n",
+    "print(\"declared opset:\", [(o.domain or \"ai.onnx\", o.version) for o in onnx.load(str(qdq_path)).opset_import])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "opset-md",
+   "metadata": {},
+   "source": [
+    "The two files declare different opsets because those are the two library defaults: `export_onnx`\n",
+    "asks for opset 17 and `export_qdq` for opset 18, the opset the Q/DQ translations it registers are\n",
+    "written against."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "helpers",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def report(name, k, n, z=1.96):\n",
+    "    \"A count with its n and its Wilson 95% interval\"\n",
+    "    p, d, centre = k/n, 1 + z**2/n, k/n + z**2/(2*n)\n",
+    "    half = z*((p*(1-p) + z**2/(4*n))/n)**0.5\n",
+    "    print(f\"{name}: {k}/{n} = {p:.4f}  Wilson 95% [{(centre-half)/d:.4f}, {(centre+half)/d:.4f}]\")\n",
+    "\n",
+    "def score(onnx_path, batches):\n",
+    "    \"Correct predictions and n for an ONNX file, over the batches it is given\"\n",
+    "    onnx_model = ONNXModel(onnx_path, device=\"cpu\")\n",
+    "    correct = sum(int((onnx_model(xb).argmax(-1) == yb).sum()) for xb, yb in batches)\n",
+    "    return correct, sum(len(yb) for _, yb in batches)\n",
+    "\n",
+    "def score_torch(torch_model, batches):\n",
+    "    \"The same count for a torch model, over the same batches\"\n",
+    "    torch_model.eval()\n",
+    "    with torch.no_grad():\n",
+    "        correct = sum(int((torch_model(xb).argmax(-1) == yb).sum()) for xb, yb in batches)\n",
+    "    return correct, sum(len(yb) for _, yb in batches)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "verify-md",
+   "metadata": {},
+   "source": [
+    "`verify_qdq` reports how often the exported graph and the quantized model agree on the class. That\n",
+    "is a parity guard only if the reference predictions vary, so count them first:"
    ]
   },
   {
@@ -189,192 +465,115 @@
    "execution_count": null,
    "id": "verify",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "reference predictions per class: [165, 91]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "vacuity warning: False\n",
+      "argmax agreement: 256/256 = 1.0000  Wilson 95% [0.9852, 1.0000]\n"
+     ]
+    }
+   ],
    "source": [
-    "is_valid = verify_onnx(model, onnx_path, sample)\n",
-    "print(f\"Verification {'passed' if is_valid else 'FAILED'}: ONNX outputs {'match' if is_valid else 'do not match'} PyTorch!\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "quantize-header",
-   "metadata": {},
-   "source": [
-    "## 5. Export with INT8 Quantization\n",
+    "probe = torch.cat([xb for xb, _ in valid_batches[:4]])  # 256 real validation images\n",
     "\n",
-    "For even smaller models and faster inference, apply INT8 quantization during export:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "quantized-export",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Dynamic quantization (no calibration data needed)\n",
-    "quantized_path = export_onnx(\n",
-    "    model.cpu(), sample, \"model_int8.onnx\",\n",
-    "    quantize=True,\n",
-    "    quantize_mode=\"dynamic\"\n",
-    ")\n",
-    "print(f\"Exported quantized model to: {quantized_path}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "static-quant",
-   "metadata": {},
-   "source": [
-    "For better accuracy, use **static quantization** with calibration data:\n",
-    "\n",
-    "```python\n",
-    "# Static quantization with calibration\n",
-    "quantized_path = export_onnx(\n",
-    "    model, sample, \"model_int8_static.onnx\",\n",
-    "    quantize=True,\n",
-    "    quantize_mode=\"static\",\n",
-    "    calibration_data=dls.train  # Use training data for calibration\n",
-    ")\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "compare-header",
-   "metadata": {},
-   "source": [
-    "## 6. Compare Model Sizes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "compare-sizes",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "def get_size_mb(path):\n",
-    "    return os.path.getsize(path) / 1e6\n",
-    "\n",
-    "# Save PyTorch model for comparison\n",
-    "torch.save(model.state_dict(), \"model.pt\")\n",
-    "\n",
-    "pt_size = get_size_mb(\"model.pt\")\n",
-    "onnx_size = get_size_mb(\"model.onnx\")\n",
-    "int8_size = get_size_mb(quantized_path)\n",
-    "\n",
-    "print(f\"PyTorch model:    {pt_size:.2f} MB\")\n",
-    "print(f\"ONNX model:       {onnx_size:.2f} MB\")\n",
-    "print(f\"ONNX INT8 model:  {int8_size:.2f} MB ({pt_size/int8_size:.1f}x smaller)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "inference-header",
-   "metadata": {},
-   "source": [
-    "## 7. Running Inference with ONNX Runtime\n",
-    "\n",
-    "Use the `ONNXModel` wrapper for easy inference:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "inference",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Load the ONNX model\n",
-    "onnx_model = ONNXModel(\"model.onnx\", device=\"cpu\")\n",
-    "\n",
-    "# Run inference\n",
-    "test_input = torch.randn(1, 3, 64, 64)\n",
-    "output = onnx_model(test_input)\n",
-    "\n",
-    "print(f\"Output shape: {output.shape}\")\n",
-    "print(f\"Predictions: {output}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "benchmark-header",
-   "metadata": {},
-   "source": [
-    "### Benchmark Inference Speed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "benchmark",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import time\n",
-    "\n",
-    "def benchmark(fn, input_tensor, warmup=10, runs=100):\n",
-    "    # Warmup\n",
-    "    for _ in range(warmup):\n",
-    "        fn(input_tensor)\n",
-    "    \n",
-    "    # Benchmark\n",
-    "    start = time.perf_counter()\n",
-    "    for _ in range(runs):\n",
-    "        fn(input_tensor)\n",
-    "    elapsed = (time.perf_counter() - start) / runs * 1000\n",
-    "    return elapsed\n",
-    "\n",
-    "test_input = torch.randn(1, 3, 64, 64)\n",
-    "\n",
-    "# PyTorch\n",
-    "model.eval()\n",
     "with torch.no_grad():\n",
-    "    pt_time = benchmark(model, test_input)\n",
+    "    reference = torch.cat([qmodel(xb).argmax(-1) for xb, _ in valid_batches[:4]])\n",
+    "print(\"reference predictions per class:\", torch.bincount(reference, minlength=2).tolist())\n",
     "\n",
-    "# ONNX\n",
-    "onnx_model = ONNXModel(\"model.onnx\")\n",
-    "onnx_time = benchmark(onnx_model, test_input)\n",
-    "\n",
-    "# ONNX INT8\n",
-    "onnx_int8 = ONNXModel(quantized_path)\n",
-    "int8_time = benchmark(onnx_int8, test_input)\n",
-    "\n",
-    "print(f\"PyTorch inference: {pt_time:.2f} ms\")\n",
-    "print(f\"ONNX inference:    {onnx_time:.2f} ms ({pt_time/onnx_time:.1f}x faster)\")\n",
-    "print(f\"ONNX INT8:         {int8_time:.2f} ms ({pt_time/int8_time:.1f}x faster)\")"
+    "with warnings.catch_warnings(record=True) as caught:\n",
+    "    warnings.simplefilter('always')\n",
+    "    agreement = verify_qdq(qmodel, qdq_path, probe, n_batches=4)\n",
+    "print(\"vacuity warning:\", any('vacuous' in str(w.message) for w in caught))\n",
+    "report(\"argmax agreement\", round(agreement * len(probe)), len(probe))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "params-header",
+   "id": "verify-read",
    "metadata": {},
    "source": [
-    "## 8. Parameter Reference\n",
+    "The exported graph and the quantized model agree on every probe input, and the reference predicts\n",
+    "both classes rather than one: a parity guard, not the agreement a single-class reference returns\n",
+    "whatever the graph computes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "score-md",
+   "metadata": {},
+   "source": [
+    "The two files and the PyTorch model they came from, scored on the same batches. `verify_onnx` above\n",
+    "compares the file's output against PyTorch's on one random batch-1 input within a tolerance, which is\n",
+    "not an accuracy, so the torch model is scored the same way as the files rather than read off that\n",
+    "check:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "score",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FP32 PyTorch: 1375/1472 = 0.9341  Wilson 95% [0.9203, 0.9457]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FP32 ONNX: 1375/1472 = 0.9341  Wilson 95% [0.9203, 0.9457]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INT8 QDQ ONNX: 1373/1472 = 0.9327  Wilson 95% [0.9188, 0.9444]\n"
+     ]
+    }
+   ],
+   "source": [
+    "report(\"FP32 PyTorch\", *score_torch(model, valid_batches))\n",
+    "report(\"FP32 ONNX\", *score(float_path, valid_batches))\n",
+    "report(\"INT8 QDQ ONNX\", *score(qdq_path, valid_batches))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "score-read",
+   "metadata": {},
+   "source": [
+    "Three rows over the same batches: the model in PyTorch, the float file, and the INT8 file. PyTorch\n",
+    "and the float file come out on the same count, which is what the export is asked to preserve; the\n",
+    "INT8 row's Wilson interval overlaps both, so this single run does not order the three."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "scope",
+   "metadata": {},
+   "source": [
+    "## Measured on\n",
     "\n",
-    "### export_onnx Parameters\n",
-    "\n",
-    "| Parameter | Default | Description |\n",
-    "|-----------|---------|-------------|\n",
-    "| `model` | Required | PyTorch model to export |\n",
-    "| `sample` | Required | Example input tensor (with batch dimension) |\n",
-    "| `output_path` | Required | Output .onnx file path |\n",
-    "| `opset_version` | `18` | ONNX opset version |\n",
-    "| `quantize` | `False` | Apply INT8 quantization after export |\n",
-    "| `quantize_mode` | `\"dynamic\"` | `\"dynamic\"` (no calibration) or `\"static\"` |\n",
-    "| `calibration_data` | `None` | DataLoader for static quantization |\n",
-    "| `optimize` | `True` | Run ONNX graph optimizer |\n",
-    "| `dynamic_batch` | `True` | Allow variable batch size at runtime |\n",
-    "\n",
-    "### Quantization Mode Comparison\n",
-    "\n",
-    "| Mode | Calibration | Accuracy | Speed | Use Case |\n",
-    "|------|-------------|----------|-------|----------|\n",
-    "| `dynamic` | Not needed | Good | Fast export | Quick deployment |\n",
-    "| `static` | Required | Better | Slower export | Production models |"
+    "ResNet-18 (ImageNet weights, `fc` replaced), Oxford-IIIT Pet (two classes), 64px, batch 64; three\n",
+    "epochs of fine-tuning, two under `SparsifyCallback`, batch norms folded. torch 2.9.1+cu128 / onnx\n",
+    "1.17.0 / onnxruntime 1.24.1, CPU, **single run, one seed**. The three accuracies cover the same 23\n",
+    "full validation batches, n = 1472: the PyTorch row runs the folded, sparsified model in eager mode,\n",
+    "the other two go through ONNX Runtime. The parity check uses the first four batches, n = 256. No\n",
+    "latency is measured, and no non-sparse baseline is scored."
    ]
   },
   {
@@ -384,50 +583,30 @@
    "source": [
     "## Summary\n",
     "\n",
-    "| Step | Tool | Purpose |\n",
-    "|------|------|----------|\n",
-    "| Compress | SparsifyCallback, PruneCallback, etc. | Reduce model complexity |\n",
-    "| Fold BN | BN_Folder | Eliminate batch norm overhead |\n",
-    "| Export | export_onnx | Convert to deployment format |\n",
-    "| Verify | verify_onnx | Ensure correctness |\n",
-    "| Quantize | `quantize=True` | Store weights as INT8 instead of FP32 |\n",
-    "| Deploy | ONNXModel | Run inference |\n",
+    "| Tool | What it gives you |\n",
+    "|------|-------------------|\n",
+    "| `SparsifyCallback(sparsity=0.5, ...)` | Half of every convolution's weights zeroed during the fit, with a per-layer report |\n",
+    "| `BN_Folder().fold(model)` | The same model with every `BatchNorm2d` folded into its convolution |\n",
+    "| `export_onnx(model, sample, path)` | A float ONNX file, dynamic batch, opset 17 |\n",
+    "| `verify_onnx(model, path, sample)` | Whether the file's outputs match PyTorch's within tolerance |\n",
+    "| `ONNXModel(path)` | A callable that runs the file through ONNX Runtime |\n",
+    "| `Quantizer(backend='pt2e')` | A symmetric INT8 graph, calibrated on the batches you hand it |\n",
+    "| `export_qdq(model, sample, path)` | An ONNX file whose Q/DQ pairs survived the export, opset 18 |\n",
+    "| `qdq_stats(path)` | Node counts, per-channel count and zero-point audit, read off the file |\n",
+    "| `verify_qdq(model, path, samples)` | Argmax agreement between the exported graph and PyTorch |\n",
     "\n",
-    "### Complete Pipeline Example\n",
-    "\n",
-    "```python\n",
-    "from fasterai.sparse.all import *\n",
-    "from fasterai.misc.all import *\n",
-    "from fasterai.export.all import *\n",
-    "\n",
-    "# 1. Train with compression\n",
-    "sp_cb = SparsifyCallback(sparsity=50, granularity='weight', ...)\n",
-    "learn.fit_one_cycle(5, cbs=sp_cb)\n",
-    "\n",
-    "# 2. Fold batch norm\n",
-    "model = BN_Folder().fold(learn.model)\n",
-    "\n",
-    "# 3. Export with quantization\n",
-    "sample = torch.randn(1, 3, 224, 224)\n",
-    "path = export_onnx(model, sample, \"model_int8.onnx\", quantize=True)\n",
-    "\n",
-    "# 4. Verify\n",
-    "assert verify_onnx(model, path, sample)\n",
-    "\n",
-    "# 5. Deploy\n",
-    "onnx_model = ONNXModel(path)\n",
-    "output = onnx_model(input_tensor)\n",
-    "```\n",
+    "Every compression ratio on this page is a fraction in [0, 1]: `sparsity=0.5` is half the weights.\n",
     "\n",
     "---\n",
     "\n",
     "## See Also\n",
     "\n",
-    "- [ONNX Exporter API](../../export/onnx_exporter.html) - Detailed API reference\n",
-    "- [BN Folding](../misc/bn_folding.html) - Fold batch norm before export\n",
-    "- [CPU Optimizer](../../misc/cpu_optimizer.html) - Alternative: TorchScript for CPU deployment\n",
-    "- [Sparsify Callback](../sparse/sparsify_callback.html) - Compress before export\n",
-    "- [Quantize Callback](../quantize/quantize_callback.html) - QAT before export"
+    "- [ONNX Exporter](../../export/onnx_exporter.html) - The API reference for every function used here\n",
+    "- [Deployable INT8 Export](../quantize/deployable_export.html) - The same export path, self-contained and without training\n",
+    "- [Quantize Callback](../quantize/quantize_callback.html) - Quantization-aware training, before the export\n",
+    "- [Precision](../../core/precision.html) - Which backend can honor which precision, and why\n",
+    "- [Sparsify Callback](../sparse/sparsify_callback.html) - The sparsification schedule used above\n",
+    "- [BN Folding](../misc/bn_folding.html) - What folding does to the model"
    ]
   },
   {
@@ -438,10 +617,8 @@
    "outputs": [],
    "source": [
     "#| include: false\n",
-    "# Cleanup\n",
-    "import os\n",
-    "for f in [\"model.onnx\", \"model.pt\", \"model_int8.onnx\"]:\n",
-    "    if os.path.exists(f): os.remove(f)"
+    "import shutil\n",
+    "shutil.rmtree(TMP, ignore_errors=True)"
    ]
   }
  ],

--- a/nbs/tutorials/prune/prune_callback.ipynb
+++ b/nbs/tutorials/prune/prune_callback.ipynb
@@ -24,7 +24,8 @@
     "#| include: false\n",
     "from nbdev.showdoc import *\n",
     "import warnings\n",
-    "warnings.filterwarnings('ignore')"
+    "warnings.filterwarnings('ignore')\n",
+    "warnings.filterwarnings('error', message='.*looks like a percent.*')  # a percent literal aborts this page"
    ]
   },
   {
@@ -126,10 +127,10 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>0</td>\n",
-       "      <td>0.594004</td>\n",
-       "      <td>0.395837</td>\n",
-       "      <td>0.834235</td>\n",
-       "      <td>00:03</td>\n",
+       "      <td>0.601222</td>\n",
+       "      <td>0.380172</td>\n",
+       "      <td>0.845061</td>\n",
+       "      <td>00:05</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
@@ -158,24 +159,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "after the warm-up epoch: 83.42% (1233/1478), Wilson 95% [81.44%, 85.23%]\n"
+      "after the warm-up epoch: 1249/1478 = 0.8451  Wilson 95% [0.8257, 0.8626]\n"
      ]
     }
    ],
    "source": [
-    "from math import sqrt\n",
+    "def report(name, k, n, z=1.96):\n",
+    "    \"A count with its n and its Wilson 95% interval\"\n",
+    "    p, d, centre = k/n, 1 + z**2/n, k/n + z**2/(2*n)\n",
+    "    half = z*((p*(1-p) + z**2/(4*n))/n)**0.5\n",
+    "    print(f\"{name}: {k}/{n} = {p:.4f}  Wilson 95% [{(centre-half)/d:.4f}, {(centre+half)/d:.4f}]\")\n",
     "\n",
-    "def report(learn, name):\n",
-    "    \"Validation accuracy with its Wilson 95% interval\"\n",
+    "def correct(learn):\n",
+    "    \"Correct predictions and n on the validation set\"\n",
     "    n = len(learn.dls.valid_ds)\n",
     "    with learn.no_bar(): acc = float(learn.validate()[1])\n",
-    "    k, z = round(acc*n), 1.96\n",
-    "    p, d = k/n, 1 + z**2/n\n",
-    "    c = p + z**2/(2*n)\n",
-    "    h = z*sqrt(p*(1-p)/n + z**2/(4*n**2))\n",
-    "    print(f\"{name}: {acc:.2%} ({k}/{n}), Wilson 95% [{(c-h)/d:.2%}, {(c+h)/d:.2%}]\")\n",
+    "    return round(acc*n), n\n",
     "\n",
-    "report(learn, \"after the warm-up epoch\")"
+    "report(\"after the warm-up epoch\", *correct(learn))"
    ]
   },
   {
@@ -215,9 +216,9 @@
    "id": "09415b3b",
    "metadata": {},
    "source": [
-    "The call below asks the pruner for a global 40% over ten epochs:\n",
+    "The call below asks the pruner for a global ratio of 0.4 over ten epochs:\n",
     "\n",
-    "- **`pruning_ratio=40`** - the ratio asked of the pruner, in percent\n",
+    "- **`pruning_ratio=0.4`** - the ratio asked of the pruner, a fraction in [0, 1] (`0.4` = 40%)\n",
     "- **`context='global'`** - compare filter importance across the whole model\n",
     "- **`criteria=large_final`** - keep the filters with the largest final weights\n",
     "- **`schedule=one_cycle`** - how the ratio grows from 0 to its target during training"
@@ -280,73 +281,73 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>0</td>\n",
-       "      <td>0.360563</td>\n",
-       "      <td>0.305785</td>\n",
-       "      <td>0.870095</td>\n",
-       "      <td>00:14</td>\n",
+       "      <td>0.354834</td>\n",
+       "      <td>0.316359</td>\n",
+       "      <td>0.871448</td>\n",
+       "      <td>00:06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>1</td>\n",
-       "      <td>0.294155</td>\n",
-       "      <td>0.344234</td>\n",
-       "      <td>0.868065</td>\n",
-       "      <td>00:17</td>\n",
+       "      <td>0.289825</td>\n",
+       "      <td>0.298112</td>\n",
+       "      <td>0.886333</td>\n",
+       "      <td>00:06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>2</td>\n",
-       "      <td>0.241100</td>\n",
-       "      <td>0.236076</td>\n",
-       "      <td>0.911367</td>\n",
-       "      <td>00:21</td>\n",
+       "      <td>0.245730</td>\n",
+       "      <td>0.237911</td>\n",
+       "      <td>0.900541</td>\n",
+       "      <td>00:07</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>3</td>\n",
-       "      <td>0.212151</td>\n",
-       "      <td>0.390594</td>\n",
-       "      <td>0.787551</td>\n",
-       "      <td>00:21</td>\n",
+       "      <td>0.228931</td>\n",
+       "      <td>0.332760</td>\n",
+       "      <td>0.872801</td>\n",
+       "      <td>00:07</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>4</td>\n",
-       "      <td>0.170587</td>\n",
-       "      <td>0.230486</td>\n",
-       "      <td>0.901218</td>\n",
-       "      <td>00:20</td>\n",
+       "      <td>0.184838</td>\n",
+       "      <td>0.218940</td>\n",
+       "      <td>0.914073</td>\n",
+       "      <td>00:08</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>5</td>\n",
-       "      <td>0.161299</td>\n",
-       "      <td>0.233577</td>\n",
-       "      <td>0.906631</td>\n",
-       "      <td>00:21</td>\n",
+       "      <td>0.213857</td>\n",
+       "      <td>0.227616</td>\n",
+       "      <td>0.915426</td>\n",
+       "      <td>00:07</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>6</td>\n",
-       "      <td>0.247981</td>\n",
-       "      <td>0.249352</td>\n",
-       "      <td>0.902571</td>\n",
-       "      <td>00:23</td>\n",
+       "      <td>0.266128</td>\n",
+       "      <td>0.235636</td>\n",
+       "      <td>0.897835</td>\n",
+       "      <td>00:08</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>7</td>\n",
-       "      <td>0.214184</td>\n",
-       "      <td>0.235729</td>\n",
-       "      <td>0.900541</td>\n",
-       "      <td>00:17</td>\n",
+       "      <td>0.241007</td>\n",
+       "      <td>0.234197</td>\n",
+       "      <td>0.904601</td>\n",
+       "      <td>00:06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>8</td>\n",
-       "      <td>0.190231</td>\n",
-       "      <td>0.228861</td>\n",
-       "      <td>0.903924</td>\n",
-       "      <td>00:14</td>\n",
+       "      <td>0.230154</td>\n",
+       "      <td>0.237446</td>\n",
+       "      <td>0.900541</td>\n",
+       "      <td>00:05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>9</td>\n",
-       "      <td>0.184666</td>\n",
-       "      <td>0.227759</td>\n",
-       "      <td>0.905277</td>\n",
-       "      <td>00:14</td>\n",
+       "      <td>0.226757</td>\n",
+       "      <td>0.228660</td>\n",
+       "      <td>0.909337</td>\n",
+       "      <td>00:05</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
@@ -362,21 +363,75 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sparsity at the end of epoch 0: 0.39%\n",
-      "Sparsity at the end of epoch 1: 1.54%\n",
-      "Sparsity at the end of epoch 2: 5.60%\n",
-      "Sparsity at the end of epoch 3: 15.91%\n",
-      "Sparsity at the end of epoch 4: 29.13%\n",
-      "Sparsity at the end of epoch 5: 36.64%\n",
-      "Sparsity at the end of epoch 6: 39.12%\n",
-      "Sparsity at the end of epoch 7: 39.79%\n",
-      "Sparsity at the end of epoch 8: 39.96%\n",
-      "Sparsity at the end of epoch 9: 40.00%\n"
+      "Pruning ratio at the end of epoch 0: 0.39%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pruning ratio at the end of epoch 1: 1.54%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pruning ratio at the end of epoch 2: 5.60%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pruning ratio at the end of epoch 3: 15.91%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pruning ratio at the end of epoch 4: 29.13%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pruning ratio at the end of epoch 5: 36.64%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pruning ratio at the end of epoch 6: 39.12%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pruning ratio at the end of epoch 7: 39.79%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pruning ratio at the end of epoch 8: 39.96%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pruning ratio at the end of epoch 9: 40.00%\n"
      ]
     }
    ],
    "source": [
-    "pr_cb = PruneCallback(pruning_ratio=40, context='global', criteria=large_final, schedule=one_cycle)\n",
+    "pr_cb = PruneCallback(pruning_ratio=0.4, context='global', criteria=large_final, schedule=one_cycle)\n",
     "learn.fit_one_cycle(10, cbs=pr_cb)"
    ]
   },
@@ -414,22 +469,22 @@
       "0.5.0.downsample.0                  Conv2d       64       128      8,192       \n",
       "0.5.1.conv1                         Conv2d       128      128      147,456     \n",
       "0.5.1.conv2                         Conv2d       128      128      147,456     \n",
-      "0.6.0.conv1                         Conv2d       128      238      274,176     \n",
-      "0.6.0.conv2                         Conv2d       238      189      404,838     \n",
-      "0.6.0.downsample.0                  Conv2d       128      189      24,192      \n",
-      "0.6.1.conv1                         Conv2d       189      13       22,113      \n",
-      "0.6.1.conv2                         Conv2d       13       189      22,113      \n",
-      "0.7.0.conv1                         Conv2d       189      1        1,701       \n",
+      "0.6.0.conv1                         Conv2d       128      239      275,328     \n",
+      "0.6.0.conv2                         Conv2d       239      183      393,633     \n",
+      "0.6.0.downsample.0                  Conv2d       128      183      23,424      \n",
+      "0.6.1.conv1                         Conv2d       183      19       31,293      \n",
+      "0.6.1.conv2                         Conv2d       19       183      31,293      \n",
+      "0.7.0.conv1                         Conv2d       183      1        1,647       \n",
       "0.7.0.conv2                         Conv2d       1        512      4,608       \n",
-      "0.7.0.downsample.0                  Conv2d       189      512      96,768      \n",
+      "0.7.0.downsample.0                  Conv2d       183      512      93,696      \n",
       "0.7.1.conv1                         Conv2d       512      1        4,608       \n",
       "0.7.1.conv2                         Conv2d       1        512      4,608       \n",
-      "1.4                                 Linear       1024     507      519,168     \n",
-      "1.8                                 Linear       507      2        1,014       \n",
+      "1.4                                 Linear       1024     506      518,144     \n",
+      "1.8                                 Linear       506      2        1,012       \n",
       "-------------------------------------------------------------------------------------\n",
-      "Total                                                              2,061,059   \n",
+      "Total                                                              2,064,446   \n",
       "Original                                                           11,704,896  \n",
-      "Reduction                                                               82.39%\n"
+      "Reduction                                                               82.36%\n"
      ]
     }
    ],
@@ -455,11 +510,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.15 GMACs at 224x224, 2.07 M parameters, 3316 conv output channels\n",
-      "conv output channels removed:  30.9%\n",
+      "1.15 GMACs at 224x224, 2.07 M parameters, 3305 conv output channels\n",
+      "conv output channels removed:  31.1%\n",
       "parameter ratio:               0.18\n",
-      "MACs ratio at 224x224:         0.6320\n",
-      "MACs ratio at 64x64:           0.6332\n"
+      "MACs ratio at 224x224:         0.6328\n",
+      "MACs ratio at 64x64:           0.6339\n"
      ]
     }
    ],
@@ -480,14 +535,14 @@
    "id": "ratio-md",
    "metadata": {},
    "source": [
-    "`pruning_ratio=40` asks the pruner for a global 40%; the cells above show what that produced here.\n",
-    "Counting the output channels of every convolution, 4800 → 3316, 30.9% removed. `0.4` to `0.7` are the\n",
-    "four ResNet stages inside the fastai body, two blocks each: the stem `0.0`, `0.4` and `0.5` keep their 64\n",
-    "and 128 channels, the removal falls on `0.6` and `0.7` — down to 13 output channels in `0.6.1.conv1` and\n",
-    "a single one in both `0.7.*.conv1` — and the head `1.4` goes from 1024 to 507 units. Neither the\n",
-    "parameter ratio (0.18) nor, in this run, the channel ratio (30.9%) equals the requested 40%: the ratio is\n",
-    "what torch-pruning targets over its prunable groups, and a group cannot go below one channel — two\n",
-    "convolutions here sit at that bound.\n"
+    "`pruning_ratio=0.4` asks the pruner for a global ratio of 0.4; the cells above show what that produced\n",
+    "here. Counting the output channels of every convolution, 4800 → 3305, 31.1% removed. In the report,\n",
+    "`0.4` to `0.7` are module paths and not ratios: the four ResNet stages inside the fastai body, two\n",
+    "blocks each. The stem `0.0`, `0.4` and `0.5` keep their 64 and 128 channels, the removal falls on `0.6`\n",
+    "and `0.7` — down to 19 output channels in `0.6.1.conv1` and a single one in both `0.7.*.conv1` — and the\n",
+    "head `1.4` goes from 1024 to 506 units. Neither the parameter ratio (0.18) nor, in this run, the channel\n",
+    "ratio (31.1%) equals the 0.4 asked for: the ratio is what torch-pruning targets over its prunable groups,\n",
+    "and a group cannot go below one channel — two convolutions here sit at that bound."
    ]
   },
   {
@@ -500,12 +555,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "after pruning: 90.53% (1338/1478), Wilson 95% [88.93%, 91.92%]\n"
+      "after pruning: 1344/1478 = 0.9093  Wilson 95% [0.8936, 0.9229]\n"
      ]
     }
    ],
    "source": [
-    "report(learn, \"after pruning\")"
+    "report(\"after pruning\", *correct(learn))"
    ]
   },
   {
@@ -515,11 +570,11 @@
    "source": [
     "**Scope.** ResNet-18 pretrained on ImageNet, PETS cat/dog labels, images resized to 64 px; one warm-up\n",
     "epoch, then ten epochs with `PruneCallback`; single run, no seed fixed. Both accuracies are measured on\n",
-    "the 1478 validation images and printed with their Wilson 95% interval, but they come from different\n",
-    "training budgets — one epoch against eleven — so they are not a dense-versus-pruned comparison. The\n",
-    "absolute GMACs are for a 224x224 batch-1 input rather than the 64 px training resolution; the MACs ratio\n",
-    "barely moves with that choice, 0.6320 at 224x224 against 0.6332 at 64x64, as the cell above prints. This\n",
-    "page measures no latency.\n"
+    "the 1478 validation images and printed by `report` with their Wilson 95% interval, but they come from\n",
+    "different training budgets — one epoch against eleven — so they are not a dense-versus-pruned\n",
+    "comparison. The absolute GMACs are for a 224x224 batch-1 input rather than the 64 px training\n",
+    "resolution; the MACs ratio barely moves with that choice, 0.6328 at 224x224 against 0.6339 at 64x64, as\n",
+    "the cell above prints. This page measures no latency."
    ]
   },
   {
@@ -536,9 +591,10 @@
     "| `Pruner.print_sparsity()` | Per-layer channel counts and the total parameter reduction |\n",
     "| `tp.utils.count_ops_and_params` | MACs and parameters of a model, at a given input size |\n",
     "\n",
-    "`pruning_ratio` is a percentage. `criteria` and `schedule` take the objects exported by\n",
-    "`fasterai.core.criteria` (`large_final`, `small_final`, `random`, `movement`, `wanda`, ...) and\n",
-    "`fasterai.core.schedule` (`one_shot`, `iterative`, `agp`, `one_cycle`, `cos`, `lin`, `dsd`).\n",
+    "`pruning_ratio` is a fraction in [0, 1] (`0.4` = 40%). `criteria` and `schedule` take the objects\n",
+    "exported by `fasterai.core.criteria` (`large_final`, `small_final`, `random`, `movement`, `wanda`,\n",
+    "...) and `fasterai.core.schedule` (`one_shot`, `iterative`, `agp`, `one_cycle`, `cos`, `lin`,\n",
+    "`dsd`).\n",
     "\n",
     "---\n",
     "\n",

--- a/nbs/tutorials/quantize/quantize_callback.ipynb
+++ b/nbs/tutorials/quantize/quantize_callback.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "raw",
-   "id": "a1705706-1f6f-470a-aa2c-c16b437dd3af",
+   "id": "fm",
    "metadata": {},
    "source": [
     "---\n",
-    "description: Quantization-Aware Callback \n",
-    "output-file: tutorial.quantize_callback.html\n",
     "title: Quantize Callback\n",
+    "description: Quantization-aware training inside a fastai fit, with the FX and the pt2e flow\n",
+    "output-file: tutorial.quantize_callback.html\n",
     "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
@@ -17,376 +17,500 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73cc27b8-9a3f-4e82-b6af-d94af136d159",
+   "id": "setup",
    "metadata": {},
    "outputs": [],
    "source": [
     "#| include: false\n",
-    "import timm\n",
+    "import logging, tempfile, warnings\n",
+    "from copy import deepcopy\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
     "from fastai.vision.all import *\n",
-    "from fasterai.quantize.all import *"
+    "from torchvision.models import resnet18, ResNet18_Weights\n",
+    "\n",
+    "from fasterai.core.all import quant_spec\n",
+    "from fasterai.export.all import export_qdq, qdq_stats\n",
+    "from fasterai.quantize.all import QuantizeCallback\n",
+    "\n",
+    "warnings.filterwarnings('ignore', message='Please use quant_min')  # torch's reduce_range notice\n",
+    "warnings.filterwarnings('ignore', message='.*erase_node.*')        # torch.fx, during the pt2e convert\n",
+    "warnings.filterwarnings('ignore', message='.*export_for_training.*')  # torch.export deprecation notice\n",
+    "warnings.filterwarnings('error', message='.*looks like a percent.*')  # a percent literal aborts this page\n",
+    "logging.getLogger('torch.onnx').setLevel(logging.ERROR)            # exporter schema notes\n",
+    "TMP = Path(tempfile.mkdtemp())                                     # nothing is written to the repo"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a4v2sm5n0qo",
+   "id": "overview",
    "metadata": {},
    "source": [
     "## Overview\n",
     "\n",
-    "**Quantization-Aware Training (QAT)** simulates low-precision inference during training, allowing the model to adapt to quantization effects. This produces more accurate quantized models than post-training quantization alone.\n",
+    "`QuantizeCallback` runs quantization-aware training inside a fastai fit: fake-quantize modules go in\n",
+    "before it, the converted model comes out on `learn.model`. The backend picks the flow — `x86`,\n",
+    "`qnnpack`, `fbgemm` and `onednn` give back an FX quantized model, `pt2e` a symmetric INT8 graph.\n",
     "\n",
-    "### Why Use QAT?\n",
-    "\n",
-    "| Approach | Accuracy | Speed | When to Use |\n",
-    "|----------|----------|-------|-------------|\n",
-    "| Post-Training Quantization | Lower | Fast (no training) | Quick deployment, accuracy tolerant |\n",
-    "| **Quantization-Aware Training** | Higher | Slower (requires training) | Production models, accuracy critical |\n",
-    "\n",
-    "### Key Benefits\n",
-    "\n",
-    "- **4x smaller models** - FP32 → INT8 reduces model size by ~75%\n",
-    "- **Faster inference** - Integer operations are faster on most hardware\n",
-    "- **Maintained accuracy** - QAT minimizes accuracy degradation\n",
-    "- **Hardware compatibility** - INT8 is widely supported (CPU, mobile, edge)"
+    "Both arms below continue the same fine-tuned ResNet-18."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "g2d4edua9eh",
+   "id": "data-md",
    "metadata": {},
    "source": [
-    "## 1. Setup and Data\n",
+    "## 1. A shared starting point\n",
     "\n",
-    "First, let's load a dataset and create a model. We'll use a pretrained ResNet-34 from timm."
+    "Oxford-IIIT Pet, two classes, 64px; three epochs of fine-tuning."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b87b88bd-690a-419a-af3a-8d55ba0d885b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#| include: false\n",
-    "path = untar_data(URLs.PETS)\n",
-    "files = get_image_files(path/\"images\")\n",
-    "\n",
-    "def label_func(f): return f[0].isupper()\n",
-    "\n",
-    "dls = ImageDataLoaders.from_name_func(path, files, label_func, item_tfms=Resize(64))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "59k26kc969h",
-   "metadata": {},
-   "source": [
-    "## 2. Training with QuantizeCallback\n",
-    "\n",
-    "The `QuantizeCallback` automatically:\n",
-    "1. Prepares the model for QAT by inserting fake quantization modules\n",
-    "2. Trains with simulated INT8 precision\n",
-    "3. Converts the model to actual INT8 after training\n",
-    "\n",
-    "Simply add the callback to your training loop:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "37de3316-5651-49a4-9b77-304ddb8cb771",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/nathan/miniconda3/envs/dev/lib/python3.12/site-packages/torch/ao/quantization/observer.py:246: UserWarning: Please use quant_min and quant_max to specify the range for observers.                     reduce_range will be deprecated in a future release of PyTorch.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<style>\n",
-       "    /* Turns off some styling */\n",
-       "    progress {\n",
-       "        /* gets rid of default border in Firefox and Opera. */\n",
-       "        border: none;\n",
-       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
-       "        background-size: auto;\n",
-       "    }\n",
-       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
-       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
-       "    }\n",
-       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
-       "        background: #F44336;\n",
-       "    }\n",
-       "</style>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: left;\">\n",
-       "      <th>epoch</th>\n",
-       "      <th>train_loss</th>\n",
-       "      <th>valid_loss</th>\n",
-       "      <th>accuracy</th>\n",
-       "      <th>time</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>0</td>\n",
-       "      <td>0.497828</td>\n",
-       "      <td>0.383409</td>\n",
-       "      <td>0.817321</td>\n",
-       "      <td>00:05</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>1</td>\n",
-       "      <td>0.291996</td>\n",
-       "      <td>0.257519</td>\n",
-       "      <td>0.891746</td>\n",
-       "      <td>00:05</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>2</td>\n",
-       "      <td>0.180348</td>\n",
-       "      <td>0.229320</td>\n",
-       "      <td>0.905277</td>\n",
-       "      <td>00:04</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "pretrained_resnet_34 = timm.create_model('resnet34', pretrained=True)\n",
-    "learn = Learner(dls, pretrained_resnet_34, metrics=accuracy)\n",
-    "learn.model.fc = nn.Linear(512, 2)\n",
-    "learn.fit_one_cycle(3, 1e-3, cbs=QuantizeCallback())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5oibm2q9j54",
-   "metadata": {},
-   "source": [
-    "## 3. Evaluating the Quantized Model\n",
-    "\n",
-    "Let's compare the original and quantized models in terms of size and accuracy."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "af098696-8269-47a0-b069-eb283f5f490b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from tqdm import tqdm\n",
-    "\n",
-    "def get_model_size(model):\n",
-    "    torch.save(model.state_dict(), \"temp.p\")\n",
-    "    size = os.path.getsize(\"temp.p\") / 1e6  # Size in MB\n",
-    "    os.remove(\"temp.p\")\n",
-    "    return size\n",
-    "    \n",
-    "def compute_validation_accuracy(model, valid_dataloader, device=None):\n",
-    "    # Set the model to evaluation mode\n",
-    "    model.eval()\n",
-    "    \n",
-    "    # Use the model's device if no device is specified\n",
-    "    \n",
-    "    device = torch.device('cpu')\n",
-    "    \n",
-    "    # Move model to the specified device\n",
-    "    model = model.to(device)\n",
-    "    \n",
-    "    # Tracking correct predictions and total samples\n",
-    "    total_correct = 0\n",
-    "    total_samples = 0\n",
-    "    \n",
-    "    # Disable gradient computation for efficiency\n",
-    "    with torch.no_grad():\n",
-    "        for batch in tqdm(valid_dataloader):\n",
-    "            # Assuming batch is a tuple of (inputs, labels)\n",
-    "            # Adjust this if your dataloader returns a different format\n",
-    "            inputs, labels = batch\n",
-    "            \n",
-    "            # Move inputs and labels to the same device as the model\n",
-    "            inputs = torch.Tensor(inputs).to(device)\n",
-    "            labels = labels.to(device)\n",
-    "            \n",
-    "            # Forward pass\n",
-    "            outputs = model(inputs)\n",
-    "            \n",
-    "            # Get predictions (for classification tasks)\n",
-    "            # Use argmax along the class dimension\n",
-    "            _, predicted = torch.max(outputs, 1)\n",
-    "            \n",
-    "            # Update counters\n",
-    "            total_samples += labels.size(0)\n",
-    "            total_correct += (predicted == labels).sum().item()\n",
-    "    \n",
-    "    # Compute accuracy as a percentage\n",
-    "    accuracy = (total_correct / total_samples) * 100\n",
-    "    \n",
-    "    return accuracy"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "929c0b2c-d1a4-42df-89a3-0b257da3c4f3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pretrained_resnet_34 = timm.create_model('resnet34', pretrained=True)\n",
-    "learn_original = Learner(dls, pretrained_resnet_34, metrics=accuracy)\n",
-    "learn_original.model.fc = nn.Linear(512, 2)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4djulmbwkux",
-   "metadata": {},
-   "source": [
-    "### Size Comparison\n",
-    "\n",
-    "Create an original (non-quantized) model for comparison:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "69d396d1-703f-409c-bfb5-90c30a4d524d",
+   "id": "data",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Size of the original model: 85.27 MB\n",
-      "Size of the quantized model: 21.51 MB\n"
+      "torch 2.9.1+cu128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0, 0.3727749288082123, 0.2615922689437866, 0.8917456269264221, '00:04']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1, 0.24850593507289886, 0.21142429113388062, 0.9147496819496155, '00:04']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2, 0.1141485646367073, 0.18102337419986725, 0.9309878349304199, '00:04']\n"
      ]
     }
    ],
    "source": [
-    "print(f'Size of the original model: {get_model_size(learn_original.model):.2f} MB')\n",
-    "print(f'Size of the quantized model: {get_model_size(learn.model):.2f} MB')"
+    "print(\"torch\", torch.__version__)\n",
+    "\n",
+    "path = untar_data(URLs.PETS)\n",
+    "files = get_image_files(path/\"images\")\n",
+    "\n",
+    "def label_func(f): return f[0].isupper()\n",
+    "\n",
+    "dls = ImageDataLoaders.from_name_func(path, files, label_func, item_tfms=Resize(64), bs=64)\n",
+    "\n",
+    "torch.manual_seed(0)\n",
+    "model = resnet18(weights=ResNet18_Weights.DEFAULT)\n",
+    "model.fc = nn.Linear(512, 2)\n",
+    "\n",
+    "learn = Learner(dls, model, metrics=accuracy)\n",
+    "with learn.no_bar(): learn.fit_one_cycle(3, 1e-3)\n",
+    "base = deepcopy(learn.model)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9cy1hnwosz7",
+   "id": "helpers-md",
    "metadata": {},
    "source": [
-    "### Accuracy Verification\n",
-    "\n",
-    "Despite the 4x size reduction, the quantized model maintains good accuracy:"
+    "Every accuracy on this page goes through `report`, which prints the count `k`, its `n`, and the\n",
+    "Wilson 95% interval for that `n`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c2a29a4-be79-4f94-8fa3-bd70354a631b",
+   "id": "helpers",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def evaluate(model, dl):\n",
+    "    \"Correct predictions and n, on the CPU where a quantized model runs\"\n",
+    "    model.eval().cpu()\n",
+    "    correct = total = 0\n",
+    "    with torch.no_grad():\n",
+    "        for xb, yb in dl:\n",
+    "            correct += int((model(xb.cpu()).argmax(-1) == yb.cpu()).sum())\n",
+    "            total += len(yb)\n",
+    "    return correct, total\n",
+    "\n",
+    "def report(name, k, n, z=1.96):\n",
+    "    \"A count with its n and its Wilson 95% interval\"\n",
+    "    p, d, centre = k/n, 1 + z**2/n, k/n + z**2/(2*n)\n",
+    "    half = z*((p*(1-p) + z**2/(4*n))/n)**0.5\n",
+    "    print(f\"{name}: {k}/{n} = {p:.4f}  Wilson 95% [{(centre-half)/d:.4f}, {(centre+half)/d:.4f}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "arms-md",
+   "metadata": {},
+   "source": [
+    "## 2. Two more epochs, with and without the callback\n",
+    "\n",
+    "Seed-matched arms: both continue from the same `base` weights, `torch.manual_seed(0)` is set again\n",
+    "right before each one, and the only difference between them is the callback."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fp32",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "100%|█████████████████████████████████████████████████████████| 24/24 [00:01<00:00, 15.47it/s]\n"
+      "[0, 0.07825697213411331, 0.19201131165027618, 0.9357239603996277, '00:05']\n"
      ]
     },
     {
-     "data": {
-      "text/plain": [
-       "90.73071718538566"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1, 0.0505782850086689, 0.20074552297592163, 0.9350473880767822, '00:04']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FP32: 1382/1478 = 0.9350  Wilson 95% [0.9213, 0.9465]\n"
+     ]
     }
    ],
    "source": [
-    "compute_validation_accuracy(learn.model, dls.valid)"
+    "torch.manual_seed(0)\n",
+    "fp32 = Learner(dls, deepcopy(base), metrics=accuracy)\n",
+    "with fp32.no_bar(): fp32.fit_one_cycle(2, 1e-4)\n",
+    "\n",
+    "report(\"FP32\", *evaluate(fp32.model, dls.valid))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "qat",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model prepared for QAT successfully\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0, 0.06549660861492157, 0.18793834745883942, 0.9357239603996277, '00:06']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1, 0.051761697977781296, 0.19833843410015106, 0.9364005327224731, '00:06']\n",
+      "Converting QAT model to fully quantized model\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "model after the fit: GraphModule\n",
+      "{'backend': 'x86', 'method': 'qat', 'weight_bits': 8, 'act_bits': 8, 'qscheme': 'per_channel', 'symmetric': False, 'group_size': None, 'layer_bits': None, 'qdq_placement': None}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x86 QAT INT8: 1385/1478 = 0.9371  Wilson 95% [0.9235, 0.9484]\n"
+     ]
+    }
+   ],
+   "source": [
+    "torch.manual_seed(0)\n",
+    "qat = Learner(dls, deepcopy(base), metrics=accuracy)\n",
+    "with qat.no_bar(): qat.fit_one_cycle(2, 1e-4, cbs=QuantizeCallback(backend='x86', verbose=True))\n",
+    "\n",
+    "print(\"model after the fit:\", type(qat.model).__name__)\n",
+    "print(quant_spec(qat.model).as_dict())\n",
+    "report(\"x86 QAT INT8\", *evaluate(qat.model, dls.valid))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "xocmmqrrktj",
+   "id": "arms-read",
    "metadata": {},
    "source": [
-    "## 4. Parameter Guide\n",
-    "\n",
-    "### QuantizeCallback Parameters\n",
-    "\n",
-    "| Parameter | Default | Description |\n",
-    "|-----------|---------|-------------|\n",
-    "| `backend` | `'x86'` | Quantization backend: `'x86'` (Intel/AMD), `'qnnpack'` (ARM/mobile), `'fbgemm'` (server) |\n",
-    "| `qconfig` | `None` | Custom quantization config. If None, uses backend default |\n",
-    "\n",
-    "### Backend Selection Guide\n",
-    "\n",
-    "| Backend | Best For | Hardware |\n",
-    "|---------|----------|----------|\n",
-    "| `'x86'` | Desktop/server CPUs | Intel, AMD processors |\n",
-    "| `'qnnpack'` | Mobile deployment | ARM processors, Android, iOS |\n",
-    "| `'fbgemm'` | Server inference | Facebook's optimized backend |\n",
-    "\n",
-    "### Tips for Best Results\n",
-    "\n",
-    "1. **Train longer** - QAT benefits from more epochs to adapt to quantization noise\n",
-    "2. **Lower learning rate** - Use 1/10th the normal LR for fine-tuning\n",
-    "3. **Calibrate batch norm** - Run a few batches through the model before final conversion\n",
-    "4. **Test on target hardware** - Quantization benefits vary by platform"
+    "The two `report` lines above come from seed-matched arms, and their Wilson intervals overlap, so this\n",
+    "single run does not order them. What the cell does show is the callback running end to end: the fit\n",
+    "hands back an FX `GraphModule`, scored on the same validation set as the floating-point arm, carrying\n",
+    "the precision record `quant_spec` reads back — 8-bit weights and activations, per-channel, and\n",
+    "asymmetric, which is what the FX backends produce. The pt2e arm below prints the symmetric one."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "fpnkeawuq1q",
+   "id": "size-md",
+   "metadata": {},
+   "source": [
+    "The same two models, on disk:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "size",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FP32 state_dict: 44.78 MB\n",
+      "INT8 state_dict: 11.30 MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "def size_mb(model):\n",
+    "    torch.save(model.state_dict(), TMP/\"state.p\")\n",
+    "    return (TMP/\"state.p\").stat().st_size / 1e6\n",
+    "\n",
+    "print(f\"FP32 state_dict: {size_mb(fp32.model):.2f} MB\")\n",
+    "print(f\"INT8 state_dict: {size_mb(qat.model):.2f} MB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pt2e-md",
+   "metadata": {},
+   "source": [
+    "## 3. The pt2e flow\n",
+    "\n",
+    "`pt2e` captures the model with `torch.export`, and a captured graph runs one batch size. fastai's\n",
+    "validation loader keeps a shorter last batch, so the callback refuses before training instead of\n",
+    "during it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "refusal",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exception occured in `QuantizeCallback` when calling event `before_fit`:\n",
+      "\tpt2e QAT captures the model at one batch size, but these dataloaders yield [6, 64]: a graph captured by torch.export only runs the batch size it was captured with. Use a batch size that divides both dataset sizes, or drop the last batch of each loader.\n"
+     ]
+    }
+   ],
+   "source": [
+    "refused = Learner(dls, deepcopy(base), metrics=accuracy)\n",
+    "try:\n",
+    "    with refused.no_bar(): refused.fit_one_cycle(1, 1e-4, cbs=QuantizeCallback(backend='pt2e'))\n",
+    "except ValueError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pt2e-fit-md",
+   "metadata": {},
+   "source": [
+    "Drop that batch, and the fit runs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pt2e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pt2e: capturing the model with torch.export\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pt2e: prepared for QAT (W8A8, per_channel, qdq_placement=per_op)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0, 0.0709400549530983, 0.1948516070842743, 0.932744562625885, '00:07']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1, 0.04437658190727234, 0.19175469875335693, 0.9375, '00:07']\n",
+      "pt2e: converting the trained graph to a quantized one\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'backend': 'pt2e', 'method': 'qat', 'weight_bits': 8, 'act_bits': 8, 'qscheme': 'per_channel', 'symmetric': True, 'group_size': None, 'layer_bits': None, 'qdq_placement': 'per_op'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "dls.valid.drop_last = True  # 23 batches of 64; the 6-image remainder is dropped\n",
+    "\n",
+    "torch.manual_seed(0)\n",
+    "pt2e = Learner(dls, deepcopy(base), metrics=accuracy)\n",
+    "with pt2e.no_bar(): pt2e.fit_one_cycle(2, 1e-4, cbs=QuantizeCallback(backend='pt2e', verbose=True))\n",
+    "\n",
+    "print(quant_spec(pt2e.model).as_dict())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "export-md",
+   "metadata": {},
+   "source": [
+    "The graph it leaves behind is what `export_qdq` writes and what `qdq_stats` reads back:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "export",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[torch.onnx] Obtain model graph for `GraphModule([...]` with `torch.export.export(..., strict=False)`...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[torch.onnx] Obtain model graph for `GraphModule([...]` with `torch.export.export(..., strict=False)`... ✅\n",
+      "[torch.onnx] Run decomposition...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[torch.onnx] Run decomposition... ✅\n",
+      "[torch.onnx] Translate the graph into ONNX...\n",
+      "[torch.onnx] Translate the graph into ONNX... ✅\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "resnet18_qat_int8.onnx 11.4 MB\n",
+      "{'n_quantize': 33, 'n_dequantize': 54, 'n_per_channel': 21, 'n_nonzero_zero_point': 0, 'n_unquantized_conv_add': 0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "sample = torch.randn(64, 3, 64, 64)  # the batch size the graph was captured at\n",
+    "\n",
+    "qdq_path = export_qdq(pt2e.model.cpu(), sample, TMP/\"resnet18_qat_int8.onnx\")\n",
+    "print(qdq_path.name, f\"{qdq_path.stat().st_size / 1e6:.1f} MB\")\n",
+    "print(qdq_stats(qdq_path).as_dict())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "stats-read",
+   "metadata": {},
+   "source": [
+    "33 `QuantizeLinear` and 54 `DequantizeLinear` nodes, 21 tensors with one scale per channel, **0**\n",
+    "non-zero zero-points — what symmetric INT8 promises, counted on the file rather than trusted — and 0\n",
+    "`Add` inputs read straight from a convolution, which is the default `qdq_placement='per_op'`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "scope",
+   "metadata": {},
+   "source": [
+    "## Measured on\n",
+    "\n",
+    "ResNet-18 (ImageNet weights, `fc` replaced), Oxford-IIIT Pet as a two-class problem, 64px, batch 64,\n",
+    "torch 2.9.1+cu128, **single run**, `torch.manual_seed(0)` set before each arm. Both accuracies score\n",
+    "the model each arm produced — the floating-point model for the first arm, the converted INT8 model\n",
+    "for the second — on the CPU over the whole validation set, n = 1478; the pt2e arm drops the\n",
+    "six-image last batch and reports no accuracy. No latency is measured. The two sizes are `state_dict`\n",
+    "bytes; the ONNX size is the file `export_qdq` wrote."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "summary",
    "metadata": {},
    "source": [
     "## Summary\n",
     "\n",
-    "| Concept | Description |\n",
-    "|---------|-------------|\n",
-    "| **Quantization-Aware Training** | Training with simulated low-precision to prepare model for INT8 inference |\n",
-    "| **QuantizeCallback** | fastai callback that handles QAT preparation, training, and conversion |\n",
-    "| **Size Reduction** | ~4x smaller model (FP32 → INT8) |\n",
-    "| **Backend** | Target hardware platform (`'x86'`, `'qnnpack'`, `'fbgemm'`) |\n",
-    "| **Typical Use** | Production deployment where model size and inference speed matter |\n",
+    "| Tool | What it gives you |\n",
+    "|------|-------------------|\n",
+    "| `QuantizeCallback(backend='x86')` | An FX INT8 model on `learn.model` after the fit, converted from the fake-quantize modules it trained through |\n",
+    "| `QuantizeCallback(backend='pt2e')` | A symmetric INT8 graph, refused up front when the dataloaders yield more than one batch size |\n",
+    "| `quant_spec(model)` | The precision record the callback attached to the model it produced |\n",
+    "| `export_qdq(model, sample, path)` | A QDQ ONNX file written from that graph |\n",
+    "| `qdq_stats(path)` | Node counts, per-channel count and zero-point audit, read off the file |\n",
     "\n",
     "---\n",
     "\n",
     "## See Also\n",
     "\n",
-    "- [Quantizer](../../quantize/quantizer.html) - Lower-level quantization API with more control\n",
-    "- [Sparsifier](../../sparse/sparsifier.html) - Combine with sparsification for even smaller models\n",
-    "- [BN Folding](../misc/bn_folding.html) - Fold batch norm layers before quantization for best results\n",
-    "- [PyTorch Quantization Docs](https://pytorch.org/docs/stable/quantization.html) - Official PyTorch quantization documentation"
+    "- [Quantizer](../../quantize/quantizer.html) - Every backend and method, outside a training loop\n",
+    "- [Precision](../../core/precision.html) - Which backend can honor which precision, and why\n",
+    "- [Deployable INT8 Export](deployable_export.html) - The same export path, self-contained and without training\n",
+    "- [ONNX Export](../export/onnx_export.html) - Sparsify, fold, export and score a model through ONNX Runtime\n",
+    "- [BN Folding](../misc/bn_folding.html) - Fold batch norm into the convolutions before exporting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cleanup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| include: false\n",
+    "import shutil\n",
+    "shutil.rmtree(TMP, ignore_errors=True)"
    ]
   }
  ],


### PR DESCRIPTION
## Why

`quantize_callback` compared a QAT run against a randomly-initialized head and listed a parameter that does not exist; `onnx_export` shipped a latency table whose own output contradicted its "faster" label and never touched the Q/DQ export path; `prune_callback` still passed a percent. All three needed fraction literals and a fresh run.

## What changes

- `quantize/quantize_callback`: one fine-tuned ResNet-18 as the shared starting point; FP32 and x86-QAT arms trained identically (seed-matched) and scored with k/n + Wilson (1382 vs 1385 of 1478, overlapping, not ordered); sizes on disk; `quant_spec` printed for both arms; then a pt2e QAT arm exported with `export_qdq` and audited with `qdq_stats` (33 Q, 54 DQ, 21 per-channel, 0 non-zero zero-points). Advice grids, "best", the non-existent `qconfig` and the 14-digit accuracy are gone.
- `export/onnx_export`: train → sparsify (0.5) → fold BN → `export_onnx` / `verify_onnx` / `ONNXModel`, with the zero count read off the file's initializers (5,583,290 of 11,166,912); then pt2e on real calibration images → `export_qdq` → `qdq_stats` → a non-vacuous `verify_qdq` (reference class counts printed first; 256/256 agreement) → three accuracy rows over the same 23 batches: the model in PyTorch, the float file, the INT8 file (1375 / 1375 / 1373 of 1472, overlapping). The ORT `quantize=True` section and its benchmark are gone; the two declared opsets (17 and 18, the library defaults) are explained; artifacts live in a temp dir.
- `prune/prune_callback`: `pruning_ratio=0.4` (a fraction); the printed channel count shows what the run produced (4800 → 3305 conv output channels, 31.1 %), against the requested 40 %.
- A three-line helper prints `k/n` and the Wilson 95 % interval on each page; prose quotes the printed relation, never hand-carried bounds.

## Evidence

Executed with the in-tree fraction library; a guard turns the percent warning into an error in each hidden setup cell. 0 error outputs, 0 warnings stored, links resolving, `nbdev-clean` idempotent, `nbdev_test` default suite green; numbers reviewed against the outputs before push.

https://claude.ai/code/session_0177tJZDQTTjQdycXV1EZtdJ
