### PR TITLE
docs: walkthrough rebuilt end-to-end on PETS, quickstart executed, overview modernized

### DIFF
--- a/nbs/overview.ipynb
+++ b/nbs/overview.ipynb
@@ -2,20 +2,19 @@
  "cells": [
   {
    "cell_type": "raw",
-   "id": "98b78fa6",
+   "id": "ov000",
    "metadata": {},
    "source": [
     "---\n",
     "output-file: overview.html\n",
     "title: Overview\n",
-    "---\n",
-    "\n"
+    "---"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49a2e983",
+   "id": "ov001",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +24,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46ab51ae",
+   "id": "ov002",
    "metadata": {},
    "source": [
     "\n",
@@ -33,12 +32,13 @@
     "    <a href=\"https://pypi.org/project/fasterai/\"><img src=\"https://img.shields.io/pypi/v/fasterai?color=00a89e\"></a>\n",
     "    <a href=\"https://www.apache.org/licenses/LICENSE-2.0\"><img src=\"https://img.shields.io/github/license/nathanhubens/fasterai?color=00a89e\"></a>\n",
     "    <a href=\"https://pypi.org/project/fasterai/\"><img src=\"https://img.shields.io/badge/DOI-10.5281%2Fzenodo.6469868-y?color=00a89e\"></a>\n",
-    "</p>\n"
+    "</p>\n",
+    ""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f3adcb00",
+   "id": "ov003",
    "metadata": {},
    "source": [
     "<p align=\"center\">\n",
@@ -52,23 +52,28 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89c69e26",
+   "id": "ov004",
    "metadata": {},
    "source": [
-    "`fasterai` is a library created to make neural network **smaller** and **faster**. It essentially relies on common compression techniques for networks such as pruning, knowledge distillation, Lottery Ticket Hypothesis, ..."
+    "`fasterai` is a library created to make neural network **smaller** and **faster**. It gathers the\n",
+    "common compression techniques — sparsification, pruning, regularization, knowledge distillation,\n",
+    "quantization — and the steps that follow them: exporting the compressed model, and measuring which\n",
+    "layers can take the compression."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "145cf969",
+   "id": "ov005",
    "metadata": {},
    "source": [
-    "The core feature of `fasterai` is its Sparsifying capabilities, constructed around 4 main modules: **granularity**, **context**, **criteria**, **schedule**. Each of these modules is highly customizable, allowing you to change them according to your needs or even to come up with your own!"
+    "Each technique is built around the same four modules: **granularity**, **context**, **criteria**,\n",
+    "**schedule**. Each of them is customizable, so you can change them according to your needs or come up\n",
+    "with your own."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ea4741cc",
+   "id": "ov006",
    "metadata": {},
    "source": [
     "## Project Documentation"
@@ -76,15 +81,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d80e3c1",
+   "id": "ov007",
    "metadata": {},
    "source": [
-    "Visit [Read The Docs Project Page](https://FasterAI-Labs.github.io/fasterai/) or read following README to know more about using `fasterai`."
+    "Visit the [Read The Docs Project Page](https://FasterAI-Labs.github.io/fasterai/) or read the\n",
+    "following README to know more about using `fasterai`."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f4890a5c",
+   "id": "ov008",
    "metadata": {},
    "source": [
     "---"
@@ -92,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6654d1bb",
+   "id": "ov009",
    "metadata": {},
    "source": [
     "##  Features"
@@ -100,7 +106,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60f6ffff",
+   "id": "ov010",
    "metadata": {},
    "source": [
     "### 1. Sparsifying"
@@ -108,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3753d21",
+   "id": "ov011",
    "metadata": {},
    "source": [
     "![](imgs/sparsification.png)"
@@ -116,28 +122,31 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e26a7c69",
+   "id": "ov012",
    "metadata": {},
    "source": [
     "Make your model sparse according to a: <br>\n",
-    "- <b>Sparsity: </b> the percentage of weights that will be replaced by 0 <br>\n",
-    "- <b>Granularity: </b> the granularity at which you operate the pruning (removing weights, vectors, kernels, filters) <br>\n",
-    "- <b>Context: </b> prune either each layer independently (local pruning) or the whole model (global pruning) <br>\n",
+    "- <b>Sparsity: </b> the fraction of weights that will be replaced by 0 <br>\n",
+    "- <b>Granularity: </b> the granularity at which you operate the sparsification (weights, vectors, kernels, filters) <br>\n",
+    "- <b>Context: </b> sparsify either each layer independently (local) or the whole model (global) <br>\n",
     "- <b>Criteria: </b> the criteria used to select the weights to remove (magnitude, movement, ...) <br>\n",
-    "- <b>Schedule: </b> which schedule you want to use for pruning (one shot, iterative, gradual, ...) <br>"
+    "- <b>Schedule: </b> which schedule you want to follow (one shot, iterative, gradual, ...) <br>"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3c918aa1",
+   "id": "ov013",
    "metadata": {},
    "source": [
-    "This can be achieved by using the `SparsifyCallback(sparsity, granularity, context, criteria, schedule)`"
+    "```python\n",
+    "SparsifyCallback(sparsity=0.5, granularity='weight', context='local',\n",
+    "                 criteria=large_final, schedule=one_cycle)\n",
+    "```"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "54709b41",
+   "id": "ov014",
    "metadata": {},
    "source": [
     "### 2. Pruning"
@@ -145,7 +154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f54d80b",
+   "id": "ov015",
    "metadata": {},
    "source": [
     "![](imgs/pruning_readme.png \"Pruning\")"
@@ -153,23 +162,26 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82e7c8f8",
+   "id": "ov016",
    "metadata": {},
    "source": [
-    "Once your model has useless nodes due to zero-weights, they can be removed to not be a part of the network anymore."
+    "Once your model has useless nodes due to zero-weights, they can be removed to not be a part of the\n",
+    "network anymore. The model that comes out is structurally smaller."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "017559c4",
+   "id": "ov017",
    "metadata": {},
    "source": [
-    "This can be achieved by using the `PruneCallback(sparsity, context, criteria, schedule)`"
+    "```python\n",
+    "PruneCallback(pruning_ratio=0.3, schedule=one_cycle, context='global', criteria=large_final)\n",
+    "```"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "c9c21ee8",
+   "id": "ov018",
    "metadata": {},
    "source": [
     "### 3. Regularization"
@@ -177,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b8851fa",
+   "id": "ov019",
    "metadata": {},
    "source": [
     "![](imgs/regularization.png \"Regularization\")"
@@ -185,32 +197,27 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7835c369",
+   "id": "ov020",
    "metadata": {},
    "source": [
-    "Instead of explicitly make your network sparse, let it train towards sparse connections by pushing the weights to be as small as possible."
+    "Instead of explicitly making your network sparse, let it train towards sparse connections by\n",
+    "pushing the weights of a group to be as small as possible. Regularization follows the same\n",
+    "granularities as sparsifying."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1e27e0f8",
+   "id": "ov021",
    "metadata": {},
    "source": [
-    "Regularization can be applied to groups of weights, following the same granularities as for sparsifying, i.e.:\n",
-    "- <b>Granularity: </b> the granularity at which you operate the regularization (weights, vectors, kernels, filters, ...)"
+    "```python\n",
+    "RegularizeCallback(criteria=large_final, granularity='filter', weight=0.01)\n",
+    "```"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "08d87749",
-   "metadata": {},
-   "source": [
-    "This can be achieved by using the `RegularizeCallback(granularity)`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3823924e",
+   "id": "ov022",
    "metadata": {},
    "source": [
     "### 4. Knowledge Distillation"
@@ -218,7 +225,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ef28540",
+   "id": "ov023",
    "metadata": {},
    "source": [
     "![alt text](imgs/distillation.png \"Distillation\")"
@@ -226,15 +233,26 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e05d172",
+   "id": "ov024",
    "metadata": {},
    "source": [
-    "Distill the knowledge acquired by a big model into a smaller one, by using the `KnowledgeDistillationCallback`."
+    "Distill the knowledge acquired by a big model into a smaller one, comparing their predictions or\n",
+    "their intermediate activations."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1899d310",
+   "id": "ov025",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "KnowledgeDistillationCallback(teacher, loss=SoftTarget, weight=0.5)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ov026",
    "metadata": {},
    "source": [
     "### 5. Lottery Ticket Hypothesis"
@@ -242,7 +260,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c10d8b5e",
+   "id": "ov027",
    "metadata": {},
    "source": [
     "![](imgs/LTH.png \"Lottery Ticket Hypothesis\")"
@@ -250,15 +268,141 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63b13459",
+   "id": "ov028",
    "metadata": {},
    "source": [
-    "Find the winning ticket in your network, *i.e.* the initial subnetwork able to attain at least similar performances than the network as a whole."
+    "Find the winning ticket in your network, *i.e.* re-train a sparse subnetwork from the initial weights\n",
+    "it started with."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "fb85868f",
+   "id": "ov029",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "SparsifyCallback(sparsity=0.5, granularity='weight', context='local', criteria=large_final,\n",
+    "                 schedule=iterative, lth=True, rewind_epoch=1)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ov030",
+   "metadata": {},
+   "source": [
+    "### 6. Quantization"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ov031",
+   "metadata": {},
+   "source": [
+    "Lower the arithmetic to INT8, either after training on calibration data or during it. The\n",
+    "precision is named argument by argument, and a backend that cannot honor it refuses instead of\n",
+    "quantizing something else."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ov032",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "Quantizer(backend='pt2e', method='static', weight_bits=8, act_bits=8, qscheme='per_channel',\n",
+    "          symmetric=True).quantize(model, calibration_dl)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ov033",
+   "metadata": {},
+   "source": [
+    "### 7. Export"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ov034",
+   "metadata": {},
+   "source": [
+    "Write the compressed model as an ONNX file, then read back what the exporter produced rather than\n",
+    "what it was asked for."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ov035",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "path = export_qdq(qmodel, sample, 'model.onnx')\n",
+    "qdq_stats(path)                       # Q/DQ nodes, per-channel scales, zero-points\n",
+    "verify_qdq(qmodel, path, samples)     # argmax agreement with PyTorch\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ov036",
+   "metadata": {},
+   "source": [
+    "### 8. Analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ov037",
+   "metadata": {},
+   "source": [
+    "Measure how much each layer can take before compressing the whole model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ov038",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "analyze_sensitivity(model, sample, eval_fn, compression='pruning', level=0.5)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ov039",
+   "metadata": {},
+   "source": [
+    "### 9. Architecture rewrites"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ov040",
+   "metadata": {},
+   "source": [
+    "Fold batch norm into the preceding convolution, factorize fully-connected or convolution layers,\n",
+    "or prepare a model for CPU inference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ov041",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "BN_Folder().fold(model)\n",
+    "FC_Decomposer().decompose(model)\n",
+    "Conv_Decomposer().decompose(model, method='tucker')\n",
+    "optimize_for_cpu(model, sample)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ov042",
    "metadata": {},
    "source": [
     "---"
@@ -266,15 +410,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5xvp6sdy6d",
+   "id": "ov043",
    "metadata": {},
    "source": [
     "## The FasterAI Ecosystem\n",
     "\n",
     "fasterai is part of a family of libraries designed to make neural network optimization accessible:\n",
     "\n",
-    "| Package | Purpose | When to Use |\n",
-    "|---------|---------|-------------|\n",
+    "| Package | Purpose | Scope |\n",
+    "|---------|---------|-------|\n",
     "| **fasterai** | Compression techniques | Pruning, sparsification, distillation, quantization during training |\n",
     "| **fasterbench** | Benchmarking | Measuring model size, speed, memory, compute, and energy |\n",
     "| **fasterlatency** | Latency prediction | Hardware-aware neural architecture search |\n",
@@ -289,7 +433,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce70c57f",
+   "id": "ov044",
    "metadata": {},
    "source": [
     "##  Quick Start"
@@ -297,7 +441,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba6715dd",
+   "id": "ov045",
    "metadata": {},
    "source": [
     "### 0. Import fasterai"
@@ -305,7 +449,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfc96fda",
+   "id": "ov046",
    "metadata": {},
    "source": [
     "```python\n",
@@ -315,7 +459,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0cc4eb8d",
+   "id": "ov047",
    "metadata": {},
    "source": [
     "### 1. Create your model with fastai"
@@ -323,35 +467,36 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e9fd842",
+   "id": "ov048",
    "metadata": {},
    "source": [
     "```python\n",
-    "learn = cnn_learner(dls, model)\n",
+    "learn = vision_learner(dls, resnet18, metrics=accuracy)\n",
     "```"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3be58c4f",
+   "id": "ov049",
    "metadata": {},
    "source": [
-    "### 2. Get your Fasterai Callback"
+    "### 2. Get your fasterai callback"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8cba1a2f",
+   "id": "ov050",
    "metadata": {},
    "source": [
     "```python\n",
-    "sp_cb=SparsifyCallback(sparsity, granularity, context, criteria, schedule)\n",
+    "sp_cb = SparsifyCallback(sparsity=0.5, granularity='weight', context='local',\n",
+    "                         criteria=large_final, schedule=one_cycle)\n",
     "```"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7204ead4",
+   "id": "ov051",
    "metadata": {},
    "source": [
     "### 3. Train your model to make it sparse !"
@@ -359,17 +504,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29e8c884",
+   "id": "ov052",
    "metadata": {},
    "source": [
     "```python\n",
-    "learn.fit_one_cycle(n_epochs, cbs=sp_cb)\n",
+    "learn.fit_one_cycle(3, cbs=sp_cb)\n",
     "```"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "86880e92",
+   "id": "ov053",
+   "metadata": {},
+   "source": [
+    "Compression ratios are fractions in [0, 1]: `sparsity=0.5` zeroes half of the weights."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ov054",
    "metadata": {},
    "source": [
     "---"
@@ -377,7 +530,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "897d7368",
+   "id": "ov055",
    "metadata": {},
    "source": [
     "##  Installation"
@@ -385,12 +538,11 @@
   },
   {
    "cell_type": "markdown",
-   "id": "420f6291",
+   "id": "ov056",
    "metadata": {},
    "source": [
-    "\n",
     "```sh\n",
-    "pip install git+https://github.com/nathanhubens/fasterai.git\n",
+    "pip install git+https://github.com/FasterAI-Labs/fasterai.git\n",
     "```\n",
     "\n",
     "or \n",
@@ -402,7 +554,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94793f86",
+   "id": "ov057",
    "metadata": {},
    "source": [
     "---"
@@ -410,7 +562,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58170c73",
+   "id": "ov058",
    "metadata": {},
    "source": [
     "## Tutorials"
@@ -418,20 +570,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d95adea6",
+   "id": "ov059",
    "metadata": {},
    "source": [
     "- [Get Started with FasterAI](tutorials/walkthrough.html)\n",
+    "- [Sparsify a model while it trains](tutorials/sparse/sparsify_callback.html)\n",
+    "- [Prune filters during training](tutorials/prune/prune_callback.html)\n",
+    "- [Export a deployable INT8 model](tutorials/quantize/deployable_export.html)\n",
     "- [Create your own pruning schedule](tutorials/sparse/schedules.html)\n",
     "- [Find winning tickets using the Lottery Ticket Hypothesis](tutorials/sparse/lottery_ticket.html)\n",
     "- [Use Knowledge Distillation to help a student model to reach higher performance](tutorials/distill/distill_callback.html)\n",
-    "- [Sparsify Transformers](tutorials/sparse/transformers.html)\n",
-    "- More to come..."
+    "- [Sparsify Transformers](tutorials/sparse/transformers.html)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cc5c2350",
+   "id": "ov060",
    "metadata": {},
    "source": [
     "---"
@@ -439,7 +593,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff49eae1",
+   "id": "ov061",
    "metadata": {},
    "source": [
     "##  Citing\n",
@@ -449,7 +603,7 @@
     "  title        = {fasterai},\n",
     "  year         = 2022,\n",
     "  publisher    = {Zenodo},\n",
-    "  version      = {v0.1.6},\n",
+    "  version      = {v0.3.3},\n",
     "  doi          = {10.5281/zenodo.6469868},\n",
     "  url          = {https://doi.org/10.5281/zenodo.6469868}\n",
     "}\n",
@@ -458,7 +612,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c18f446",
+   "id": "ov062",
    "metadata": {},
    "source": [
     "---"
@@ -466,7 +620,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69fbc5c2",
+   "id": "ov063",
    "metadata": {},
    "source": [
     "## License"
@@ -474,7 +628,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95f9498c",
+   "id": "ov064",
    "metadata": {},
    "source": [
     "[Apache-2.0](https://www.apache.org/licenses/) License."
@@ -483,21 +637,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b4323f1",
+   "id": "ov065",
    "metadata": {},
    "outputs": [],
    "source": [
     "#| include: false\n",
     "![](https://capsule-render.vercel.app/api?type=waving&color=008080&height=100&section=footer)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f197eed6",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/nbs/quickstart.ipynb
+++ b/nbs/quickstart.ipynb
@@ -2,11 +2,11 @@
  "cells": [
   {
    "cell_type": "raw",
-   "id": "31ac1da9-d240-49a8-9b3f-7b62f4ad2bad",
+   "id": "qs000",
    "metadata": {},
    "source": [
     "---\n",
-    "description: A guide on FasterAI capabilities\n",
+    "description: Sparsify a model while it trains, in five cells\n",
     "output-file: quickstart.html\n",
     "title: Quick Start\n",
     "skip_showdoc: true\n",
@@ -15,164 +15,284 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "9e0b783a-ca31-474f-a3e5-02e33ab11022",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "qs001",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "Embark on a journey to supercharge your neural network models with FasterAI, a PyTorch-based library dedicated exclusively to advanced compression techniques. In today's fast-paced world, where efficiency and performance are paramount, FasterAI stands out by providing cutting-edge solutions designed to make your neural networks not just lighter, but significantly faster."
+    "#| include: false\n",
+    "import os, warnings\n",
+    "os.environ['TQDM_DISABLE'] = '1'\n",
+    "warnings.filterwarnings('ignore')\n",
+    "warnings.filterwarnings('error', message='.*looks like a percent.*')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "10dc9f7c-a568-4228-9cbd-1de968d21baa",
+   "id": "qs002",
    "metadata": {},
    "source": [
-    "## Why Choose FasterAI?\n",
+    "fasterai plugs its compression techniques into a fastai `Learner` as callbacks, so a model is\n",
+    "compressed while it trains rather than after.\n",
     "\n",
-    "* **Streamlined Efficiency**: Dive into a suite of compression methodologies, including sparsification, pruning, quantization, and knowledge distillation, each tailored to enhance model efficiency without compromising on accuracy.\n",
-    "\n",
-    "* **Edge-Ready Models**: With FasterAI, prepare your models for the edge, ensuring they run smoothly on devices with limited computational resources, from smartphones to IoT devices.\n",
-    "  \n",
-    "* **Cutting-edge Technology**: Built on the latest research in data and model compression, FasterAI offers tools that are not just powerful but also easy to integrate into your existing workflows.\n",
-    "\n",
-    "* **Versatility**: From image and video compression to deep learning model optimization, FasterAI is versatile enough to handle a wide range of compression needs, making it suitable for various industries and applications.\n",
-    "\n",
-    "* **Open and Accessible**: As a community-driven project, FasterAI encourages contributions and feedback, ensuring that the library continues to evolve to meet the needs of its users."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ad7c7abb-a899-4525-ac32-70c1f8baca8d",
-   "metadata": {},
-   "source": [
-    "## Getting Started with FasterAI\n",
-    "\n",
-    "Whether you're looking to optimize models for production, research, or hobby projects, FasterAI provides the tools and guidance to achieve your goals. Let's make your neural networks faster and lighter, together."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9af90b4c-2fcf-4925-acf9-a6c5a04f85b1",
-   "metadata": {},
-   "source": [
-    "### How to use fasterai ? "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7a061e0d-61e4-41b7-b7cb-83cc7bfac121",
-   "metadata": {},
-   "source": [
-    "FasterAI's integration with the callback system of fastai represents a significant advancement in how compression techniques can be applied to neural networks, particularly during the training phase. This approach allows for a more seamless and flexible implementation of compression strategies, making it possible to optimize models on-the-fly and potentially achieve better efficiency and performance.\n",
-    "\n",
-    "### Understanding Callbacks in fastai\n",
-    "\n",
-    "Before diving into how FasterAI leverages callbacks, it's important to understand what callbacks are in the context of the fastai library. Callbacks are a programming pattern that allows users to inject custom behavior into certain stages of the training loop or model lifecycle without altering the core logic of the training process. They can be used for a variety of purposes, such as logging metrics, modifying learning rates, or implementing early stopping.\n",
-    "\n",
-    "### FasterAI's Use of Callbacks\n",
-    "\n",
-    "FasterAI takes advantage of the callback system in fastai to integrate neural network compression techniques directly into the training process. This integration means that instead of applying compression post-training as a separate step, FasterAI allows for compression techniques like pruning, quantization, and knowledge distillation to be applied dynamically as the model trains. Here’s how it enhances the training process:\n",
-    "\n",
-    "- **Dynamic Compression:** By using callbacks, FasterAI can dynamically adjust the compression parameters based on the model's performance during training. For example, it can gradually increase the amount of pruning as the model becomes more stable, leading to a more efficient compression process that minimally impacts performance.\n",
-    "  \n",
-    "- **Real-time Optimization:** This approach enables real-time optimization of the model. As the model learns and adapts to the data, FasterAI can apply compression techniques in a way that's informed by the model's current state, potentially leading to more effective and efficient compression.\n",
-    "  \n",
-    "- **Seamless Integration:** Leveraging fastai’s callback system means that users of FasterAI can integrate compression into their training pipelines with minimal code changes. This seamless integration simplifies the process of applying advanced compression techniques, making it accessible even to those with limited experience in model optimization.\n",
-    "\n",
-    "### Practical Implications\n",
-    "\n",
-    "For practitioners, this means they can train models that are not only high-performing but also optimized for size and speed from the outset. It also opens up new possibilities for experimenting with compression techniques during training, which could lead to novel optimization strategies and more efficient models.\n",
-    "\n",
-    "In essence, FasterAI's use of the callback system in fastai democratizes the application of sophisticated neural network compression techniques, making them an integral part of the model development lifecycle rather than an afterthought. This approach aligns with the broader goal of developing AI models that are not just powerful but also efficient and adaptable to various deployment environments."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "beecdef0-2cb7-4904-bd89-8c4a986cac92",
-   "metadata": {},
-   "source": [
-    "To illustrate the practical application of FasterAI's integration with the fastai callback system for on-the-fly compression during the training phase, let's walk through an example. This example will demonstrate how to apply dynamic pruning to a neural network model while it's being trained, leveraging the callback system for seamless integration.\n",
-    "\n",
-    "### Setting Up Your Environment\n",
-    "\n",
-    "First, ensure you have both fastai and FasterAI installed in your Python environment. If you haven't installed these libraries yet, you can do so using pip:\n",
-    "\n",
-    "```bash\n",
-    "pip install fastai fasterai\n",
-    "```\n",
-    "\n",
-    "### Importing Necessary Libraries\n",
-    "\n",
-    "Begin by importing the required libraries from fasterai:\n",
-    "\n",
-    "```python\n",
-    "from fasterai.sparse.all import *\n",
-    "```\n",
-    "\n",
-    "### Defining the Dataloader and Learner\n",
-    "\n",
-    "Just get your favorite Dataloader and Learner as usual with `fastai`:\n",
-    "\n",
-    "```python\n",
-    "dls = get_dls()\n",
-    "learner = get_learner()\n",
-    "```\n",
-    "\n",
-    "### Applying Dynamic Sparsification with a Callback\n",
-    "\n",
-    "Now, integrate FasterAI's dynamic sparsification into the training process by adding the `SparsifyCallback` to your model. This callback will apply sparsify dynamically based on the defined parameters:\n",
-    "\n",
-    "```python\n",
-    "sparsify_callback = SparsifyCallback(sparsity, granularity, context, criteria, schedule)\n",
-    "learner.fit(n_epoch, max_lr, cbs=[sparsify_callback])\n",
-    "```\n",
-    "\n",
-    "In this example, `SparsifyCallback` is initialized with different parameters (see the [tutorial](tutorials/sparse/sparsifier.html) to better understand those parameters). The `fit` method trains the model for `n_epochs`, and the `SparsifyCallback` is passed through the `cbs` (callbacks) parameter, enabling dynamic sparsification during the training process.\n",
-    "\n",
-    "### Observing the Effects\n",
-    "\n",
-    "After training, you can evaluate the model's performance and size to observe the effects of dynamic sparsification. You should notice a reduction in the model size with minimal impact on accuracy, showcasing the efficiency of integrating compression techniques during training.\n",
-    "\n",
-    "### Conclusion\n",
-    "\n",
-    "This example demonstrates how FasterAI's integration with the fastai callback system allows for the application of compression techniques like sparsification directly within the training loop. By leveraging callbacks, you can dynamically optimize your neural network models, making them lighter and faster without a significant compromise on performance. This approach not only simplifies the compression process but also opens up new avenues for creating efficient AI models optimized for various deployment scenarios."
+    "```sh\n",
+    "pip install fasterai\n",
+    "```"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b43a93bf-b95c-4815-ad12-c31b66b0533b",
+   "id": "qs003",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from fastai.vision.all import *\n",
+    "from fasterai.sparse.all import *"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "rqrzt88y7uk",
+   "id": "qs004",
+   "metadata": {},
+   "source": [
+    "A ResNet-18 on the PETS cat/dog task, images resized to 64 px:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "qs005",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = untar_data(URLs.PETS)\n",
+    "files = get_image_files(path/\"images\")\n",
+    "\n",
+    "def label_func(f): return f[0].isupper()\n",
+    "\n",
+    "dls = ImageDataLoaders.from_name_func(path, files, label_func, item_tfms=Resize(64))\n",
+    "learn = vision_learner(dls, resnet18, metrics=accuracy)\n",
+    "learn.unfreeze()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qs006",
+   "metadata": {},
+   "source": [
+    "`SparsifyCallback` zeroes half of the convolution weights over the fit, layer by layer, keeping the\n",
+    "largest magnitudes. It prints the sparsity reached at the end of each epoch, then a per-layer report."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "qs007",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsifying weight until a sparsity of 50.00%\n",
+      "Saving Weights at epoch 0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "    /* Turns off some styling */\n",
+       "    progress {\n",
+       "        /* gets rid of default border in Firefox and Opera. */\n",
+       "        border: none;\n",
+       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "        background-size: auto;\n",
+       "    }\n",
+       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
+       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
+       "    }\n",
+       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "        background: #F44336;\n",
+       "    }\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: left;\">\n",
+       "      <th>epoch</th>\n",
+       "      <th>train_loss</th>\n",
+       "      <th>valid_loss</th>\n",
+       "      <th>accuracy</th>\n",
+       "      <th>time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>0.618441</td>\n",
+       "      <td>0.660923</td>\n",
+       "      <td>0.841678</td>\n",
+       "      <td>00:06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>0.332341</td>\n",
+       "      <td>0.222465</td>\n",
+       "      <td>0.905954</td>\n",
+       "      <td>00:08</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>0.175007</td>\n",
+       "      <td>0.205939</td>\n",
+       "      <td>0.918133</td>\n",
+       "      <td>00:07</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsity at the end of epoch 0: 10.40%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsity at the end of epoch 1: 48.30%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsity at the end of epoch 2: 50.00%\n",
+      "Final Sparsity: 50.00%\n",
+      "\n",
+      "Sparsity Report:\n",
+      "--------------------------------------------------------------------------------\n",
+      "Layer                          Type            Params     Zeros      Sparsity  \n",
+      "--------------------------------------------------------------------------------\n",
+      "0.0                            Conv2d          9,408      4,702         49.98%\n",
+      "0.4.0.conv1                    Conv2d          36,864     18,430        49.99%\n",
+      "0.4.0.conv2                    Conv2d          36,864     18,430        49.99%\n",
+      "0.4.1.conv1                    Conv2d          36,864     18,430        49.99%\n",
+      "0.4.1.conv2                    Conv2d          36,864     18,430        49.99%\n",
+      "0.5.0.conv1                    Conv2d          73,728     36,862        50.00%\n",
+      "0.5.0.conv2                    Conv2d          147,456    73,725        50.00%\n",
+      "0.5.0.downsample.0             Conv2d          8,192      4,094         49.98%\n",
+      "0.5.1.conv1                    Conv2d          147,456    73,725        50.00%\n",
+      "0.5.1.conv2                    Conv2d          147,456    73,725        50.00%\n",
+      "0.6.0.conv1                    Conv2d          294,912    147,452       50.00%\n",
+      "0.6.0.conv2                    Conv2d          589,824    294,905       50.00%\n",
+      "0.6.0.downsample.0             Conv2d          32,768     16,382        49.99%\n",
+      "0.6.1.conv1                    Conv2d          589,824    294,905       50.00%\n",
+      "0.6.1.conv2                    Conv2d          589,824    294,905       50.00%\n",
+      "0.7.0.conv1                    Conv2d          1,179,648  589,811       50.00%\n",
+      "0.7.0.conv2                    Conv2d          2,359,296  1,179,624     50.00%\n",
+      "0.7.0.downsample.0             Conv2d          131,072    65,533        50.00%\n",
+      "0.7.1.conv1                    Conv2d          2,359,296  1,179,624     50.00%\n",
+      "0.7.1.conv2                    Conv2d          2,359,296  1,179,624     50.00%\n",
+      "--------------------------------------------------------------------------------\n",
+      "Overall                        all             11,166,912 5,583,318     50.00%\n"
+     ]
+    }
+   ],
+   "source": [
+    "sp_cb = SparsifyCallback(sparsity=0.5, granularity='weight', context='local',\n",
+    "                         criteria=large_final, schedule=one_cycle)\n",
+    "learn.fit_one_cycle(3, cbs=sp_cb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qs008",
+   "metadata": {},
+   "source": [
+    "Accuracy on the 1478 validation images, with its Wilson 95% interval (single run):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "qs009",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "50% sparse: 91.81% (1357/1478), Wilson 95% [90.30%, 93.10%]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from math import sqrt\n",
+    "\n",
+    "def report(learn, name):\n",
+    "    \"Validation accuracy with its Wilson 95% interval\"\n",
+    "    n = len(learn.dls.valid_ds)\n",
+    "    with learn.no_bar(): acc = float(learn.validate()[1])\n",
+    "    k, z = round(acc*n), 1.96\n",
+    "    p, d = k/n, 1 + z**2/n\n",
+    "    c = p + z**2/(2*n)\n",
+    "    h = z*sqrt(p*(1-p)/n + z**2/(4*n**2))\n",
+    "    print(f\"{name}: {acc:.2%} ({k}/{n}), Wilson 95% [{(c-h)/d:.2%}, {(c+h)/d:.2%}]\")\n",
+    "\n",
+    "report(learn, \"50% sparse\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qs010b",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "| Tool | What it gives you |\n",
+    "|------|-------------------|\n",
+    "| `SparsifyCallback(sparsity, granularity, context, criteria, schedule)` | Weights zeroed during training, following the schedule |\n",
+    "| `Sparsifier(model, granularity, context, criteria)` | The same zeroing, outside a training loop |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qs010",
    "metadata": {},
    "source": [
     "---\n",
     "\n",
-    "## Summary\n",
-    "\n",
-    "| Tool | Purpose |\n",
-    "|------|---------|\n",
-    "| `Sparsifier` | Zero out weights (unstructured compression) |\n",
-    "| `SparsifyCallback` | Sparsification during fastai training |\n",
-    "| `Pruner` | Remove entire filters (structured compression) |\n",
-    "| `PruneCallback` | Structured pruning during fastai training |\n",
-    "| `Quantizer` | Reduce weight precision to INT8 |\n",
-    "| `KnowledgeDistillationCallback` | Transfer knowledge from teacher to student |\n",
-    "| `benchmark()` | Measure model size, speed, compute, memory |\n",
-    "\n",
     "## See Also\n",
     "\n",
-    "- [Sparsifier](sparse/sparsifier.html) - Detailed sparsification API\n",
-    "- [Pruner](prune/pruner.html) - Structured pruning API\n",
-    "- [Quantizer](quantize/quantizer.html) - Quantization API\n",
-    "- [Knowledge Distillation](distill/distillation_callback.html) - Teacher-student training\n",
-    "- [Schedules](core/schedules.html) - Control compression progression\n",
-    "- [Sensitivity Analysis](analyze/sensitivity.html) - Find optimal per-layer compression"
+    "- [Walkthrough](tutorials/walkthrough.html) - the same model through sparsify, prune, quantize and export\n",
+    "- [Sparsifier](sparse/sparsifier.html), [Pruner](prune/pruner.html), [Quantizer](quantize/quantizer.html),\n",
+    "  [Knowledge Distillation](distill/distillation_callback.html) - the API pages of each technique\n",
+    "- [Granularity](core/granularity.html), [Criteria](core/criteria.html), [Schedules](core/schedules.html) -\n",
+    "  the arguments the callbacks take"
    ]
   }
  ],

--- a/nbs/tutorials/walkthrough.ipynb
+++ b/nbs/tutorials/walkthrough.ipynb
@@ -2,11 +2,11 @@
  "cells": [
   {
    "cell_type": "raw",
-   "id": "2bb19b73",
+   "id": "wk000",
    "metadata": {},
    "source": [
     "---\n",
-    "description: Walkthrough \n",
+    "description: One model from a fine-tune to a deployable INT8 ONNX file\n",
     "output-file: tutorial.walkthrough.html\n",
     "title: Walkthrough\n",
     "skip_showdoc: true\n",
@@ -17,436 +17,156 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4669f87c",
+   "id": "wk001",
    "metadata": {},
    "outputs": [],
    "source": [
     "#| include: false\n",
-    "\n",
-    "import warnings\n",
+    "import os, logging, warnings, contextlib, io\n",
+    "os.environ['TQDM_DISABLE'] = '1'\n",
     "warnings.filterwarnings('ignore')\n",
+    "warnings.filterwarnings('error', message='.*looks like a percent.*')\n",
+    "logging.getLogger('torch.onnx._internal.exporter._schemas').setLevel(logging.ERROR)\n",
+    "with contextlib.redirect_stderr(io.StringIO()):\n",
+    "    try: import torchao  # noqa: F401\n",
+    "    except Exception: pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wk002",
+   "metadata": {},
+   "source": [
+    "## Overview\n",
     "\n",
+    "One model through the four steps fasterai composes: `SparsifyCallback` zeroes weights during training,\n",
+    "`Pruner` removes filters, `Quantizer` lowers the arithmetic to INT8, `export_qdq` writes an ONNX file a\n",
+    "runtime can read. Every measured number below is printed by a cell on this page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "wk003",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from fastai.vision.all import *\n",
-    "from fasterbench.benchmark import compute_size, compute_speed_multi\n",
+    "from fasterai.sparse.all import *\n",
+    "from fasterai.prune.all import *\n",
+    "from fasterai.core.all import quant_spec\n",
+    "from fasterai.quantize.quantizer import Quantizer\n",
+    "from fasterai.export.all import export_onnx, export_qdq, qdq_stats, verify_qdq, ONNXModel\n",
     "\n",
-    "# Helper functions for cleaner code\n",
-    "def get_num_parameters(model):\n",
-    "    \"Get the number of parameters in a model\"\n",
-    "    return compute_size(model).num_params\n",
+    "import tempfile, torch_pruning as tp\n",
+    "from math import sqrt\n",
     "\n",
-    "def get_model_size(model):\n",
-    "    \"Get the disk size in bytes of a model\"\n",
-    "    return compute_size(model).disk_bytes\n",
-    "\n",
-    "def evaluate_cpu_speed(model, sample):\n",
-    "    \"Evaluate CPU inference speed, returns (mean_ms,) for backward compatibility\"\n",
-    "    result = compute_speed_multi(model.cpu().eval(), sample.cpu(), devices=['cpu'])\n",
-    "    return (result['cpu'].mean_ms,)"
+    "tmp = Path(tempfile.mkdtemp())   # every file this page writes goes here"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd812e13",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#| include: false\n",
-    "\n",
-    "def get_dls(size, bs):\n",
-    "    path = URLs.IMAGENETTE_160\n",
-    "    source = untar_data(path)\n",
-    "    blocks=(ImageBlock, CategoryBlock)\n",
-    "    tfms = [RandomResizedCrop(size, min_scale=0.35), FlipItem(0.5)]\n",
-    "    batch_tfms = [Normalize.from_stats(*imagenet_stats)]\n",
-    "\n",
-    "    csv_file = 'noisy_imagenette.csv'\n",
-    "    inp = pd.read_csv(source/csv_file)\n",
-    "    dblock = DataBlock(blocks=blocks,\n",
-    "               splitter=ColSplitter(),\n",
-    "               get_x=ColReader('path', pref=source),\n",
-    "               get_y=ColReader(f'noisy_labels_0'),\n",
-    "               item_tfms=tfms,\n",
-    "               batch_tfms=batch_tfms)\n",
-    "\n",
-    "    return dblock.dataloaders(inp, path=source, bs=bs)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15fc38d6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "size, bs = 128, 32\n",
-    "dls = get_dls(size, bs)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "aba2375b",
-   "metadata": {},
-   "source": [
-    "Let's start with a bit of context for the purpose of the demonstration. Imagine that we want to deploy a **VGG16** model on a mobile device that has limited storage capacity and that our task requires our model to run sufficiently fast. It is known that parameters and speed efficiency are not the strong points of **VGG16** but let's see what we can do with it."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4ba4137a",
-   "metadata": {},
-   "source": [
-    "Let's first check the number of parameters and the inference time of **VGG16**."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d630d029",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "learn = Learner(dls, models.vgg16_bn(num_classes=10), metrics=[accuracy])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d48b966e",
+   "id": "wk003b",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Model Size: 537.30 MB (disk), 134309962 parameters\n"
+      "torch 2.9.1+cu128 | onnx 1.17.0 | onnxruntime 1.24.1 | training on cuda:0\n"
      ]
     }
    ],
    "source": [
-    "num_parameters = get_num_parameters(learn.model)\n",
-    "disk_size = get_model_size(learn.model)\n",
-    "print(f\"Model Size: {disk_size / 1e6:.2f} MB (disk), {num_parameters} parameters\")"
+    "import onnx, onnxruntime\n",
+    "print(f\"torch {torch.__version__} | onnx {onnx.__version__} | onnxruntime {onnxruntime.__version__} \"\n",
+    "      f\"| training on {default_device()}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "c8894668-e387-426c-9c9f-c3348910d430",
+   "id": "wk004",
    "metadata": {},
    "source": [
-    "So our model has 134 millions parameters and needs 537MB of disk space in order to be stored"
+    "## 1. Data and baseline\n",
+    "\n",
+    "The cat/dog labels of the PETS dataset, images resized to 64 px."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "615c615c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model = learn.model.eval().to('cpu')\n",
-    "x,y = dls.one_batch()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "256d310a-e937-4873-8199-20151be6de0d",
+   "id": "wk005",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Inference Speed: 80.86ms\n"
+      "5912 training images, 1478 validation images, majority class 66.91%\n"
      ]
     }
    ],
    "source": [
-    "print(f'Inference Speed: {evaluate_cpu_speed(learn.model, x[0][None])[0]:.2f}ms')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "306ed0cf-26bc-4b17-9033-18f730e4b3f5",
-   "metadata": {},
-   "source": [
-    "And it takes **80.86 ms** to perform inference on a single image (CPU, batch 1). Every timing on this page is the mean over one block of repeated iterations after warm-up, produced by the `evaluate_cpu_speed` helper on top of `compute_speed_multi`; the blocks run once each, in the order shown, baseline first, and no dispersion is reported."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ad94bce0",
-   "metadata": {},
-   "source": [
-    "Snap ! This is more than we can afford for deployment, ideally we would like our model to take only half of that...but should we give up ? Nope, there are actually a lot of techniques that we can use to help reducing the size and improve the speed of our models! Let's see how to apply them with **FasterAI**."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "466427f7",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f7422e50",
-   "metadata": {},
-   "source": [
-    "We will first train our **VGG16** model to have a **baseline** of what performance we should expect from it."
+    "path = untar_data(URLs.PETS)\n",
+    "files = get_image_files(path/\"images\")\n",
+    "\n",
+    "def label_func(f): return f[0].isupper()\n",
+    "\n",
+    "dls = ImageDataLoaders.from_name_func(path, files, label_func, item_tfms=Resize(64))\n",
+    "\n",
+    "labels = [label_func(f.name) for f in dls.valid.items]\n",
+    "print(f\"{len(dls.train_ds)} training images, {len(dls.valid_ds)} validation images, majority class \"\n",
+    "      f\"{max(sum(labels), len(labels)-sum(labels))/len(labels):.2%}\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3c2f5a4a",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<style>\n",
-       "    /* Turns off some styling */\n",
-       "    progress {\n",
-       "        /* gets rid of default border in Firefox and Opera. */\n",
-       "        border: none;\n",
-       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
-       "        background-size: auto;\n",
-       "    }\n",
-       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
-       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
-       "    }\n",
-       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
-       "        background: #F44336;\n",
-       "    }\n",
-       "</style>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: left;\">\n",
-       "      <th>epoch</th>\n",
-       "      <th>train_loss</th>\n",
-       "      <th>valid_loss</th>\n",
-       "      <th>accuracy</th>\n",
-       "      <th>time</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>0</td>\n",
-       "      <td>2.084260</td>\n",
-       "      <td>1.887413</td>\n",
-       "      <td>0.333758</td>\n",
-       "      <td>00:11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>1</td>\n",
-       "      <td>1.658447</td>\n",
-       "      <td>1.451500</td>\n",
-       "      <td>0.524076</td>\n",
-       "      <td>00:10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>2</td>\n",
-       "      <td>1.379249</td>\n",
-       "      <td>1.647492</td>\n",
-       "      <td>0.514140</td>\n",
-       "      <td>00:10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>3</td>\n",
-       "      <td>1.235636</td>\n",
-       "      <td>1.450754</td>\n",
-       "      <td>0.536561</td>\n",
-       "      <td>00:10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>4</td>\n",
-       "      <td>1.096547</td>\n",
-       "      <td>0.920276</td>\n",
-       "      <td>0.708025</td>\n",
-       "      <td>00:10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>5</td>\n",
-       "      <td>0.939336</td>\n",
-       "      <td>0.904787</td>\n",
-       "      <td>0.713885</td>\n",
-       "      <td>00:10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>6</td>\n",
-       "      <td>0.820493</td>\n",
-       "      <td>0.774724</td>\n",
-       "      <td>0.752357</td>\n",
-       "      <td>00:10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>7</td>\n",
-       "      <td>0.675887</td>\n",
-       "      <td>0.635337</td>\n",
-       "      <td>0.791592</td>\n",
-       "      <td>00:10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>8</td>\n",
-       "      <td>0.636166</td>\n",
-       "      <td>0.582814</td>\n",
-       "      <td>0.811210</td>\n",
-       "      <td>00:10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>9</td>\n",
-       "      <td>0.581690</td>\n",
-       "      <td>0.588991</td>\n",
-       "      <td>0.811720</td>\n",
-       "      <td>00:10</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "learn.fit_one_cycle(10, 1e-4)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d59c07eb",
-   "metadata": {},
-   "source": [
-    "So we would like our network to have comparable accuracy but fewer parameters and running faster... And the first technique that we will show how to use is called **Knowledge Distillation**"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0e432c28",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5503c5d8",
-   "metadata": {},
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f6a3370f",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0f627246",
-   "metadata": {},
-   "source": [
-    "## **Knowledge Distillation**"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a25eac04",
-   "metadata": {},
-   "source": [
-    "Knowledge distillation is a simple yet very efficient way to train a model. It was introduced in 2006 by [Caruana et al.](https://www.cs.cornell.edu/~caruana/compression.kdd06.pdf). The main idea behind is to use a small model (called the **student**) to approximate the function learned by a larger and high-performing model (called the **teacher**). This can be done by using the large model to pseudo-label the data. This idea has been used very recently to [break the state-of-the-art accuracy on ImageNet](https://arxiv.org/abs/1911.04252).\n",
-    "\n",
-    "When we train our model for classification, we usually use a softmax as last layer. This softmax has the particularity to squish low value logits towards **0**, and the highest logit towards **1**. This has the effect of completely losing all the inter-class information, or what is sometimes called the *dark knowledge*. This is the information that is valuable and that we want to transfer from the teacher to the student.\n",
-    "\n",
-    "To do so, we still use a regular classification loss but at the same time, we'll use another loss, computed between the *softened* logits of the teacher (our *soft labels*) and the *softened* logits of the student (our *soft predictions*). Those soft values are obtained when you use a **soft-softmax**, that avoids squishing the values at its output. Our implementation follows [this paper](http://cs230.stanford.edu/files_winter_2018/projects/6940224.pdf) and the basic principle of training is represented in the figure below:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4d09a78e",
-   "metadata": {},
-   "source": [
-    "<br>\n",
-    "\n",
-    "![](../imgs/distill.png)\n",
-    "\n",
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "507e8947",
-   "metadata": {},
-   "source": [
-    "To use **Knowledge Distillation** with FasterAI, you only need to use this callback when training your student model:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6149d8c9",
-   "metadata": {},
-   "source": [
-    "<br>\n",
-    "\n",
-    "<blockquote>\n",
-    "<pre><b><i> KnowledgeDistillation(teacher.model, loss) </i></b></pre>\n",
-    "<p style=\"font-size: 15px\"><i>\n",
-    "You only need to give to the callback function your teacher learner. Behind the scenes, FasterAI will take care of making your model train using knowledge distillation.\n",
-    "</i></p>\n",
-    "</blockquote>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "83011770",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fae4a926",
+   "id": "wk007",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fasterai.distill.all import *"
+    "def report(learn, name):\n",
+    "    \"Validation accuracy with its Wilson 95% interval\"\n",
+    "    n = len(learn.dls.valid_ds)\n",
+    "    with learn.no_bar(): acc = float(learn.validate()[1])\n",
+    "    k, z = round(acc*n), 1.96\n",
+    "    p, d = k/n, 1 + z**2/n\n",
+    "    c = p + z**2/(2*n)\n",
+    "    h = z*sqrt(p*(1-p)/n + z**2/(4*n**2))\n",
+    "    print(f\"{name}: {acc:.2%} ({k}/{n}), Wilson 95% [{(c-h)/d:.2%}, {(c+h)/d:.2%}]\")\n",
+    "    return acc\n",
+    "\n",
+    "stages = []\n",
+    "\n",
+    "def record(name, model, acc=None):\n",
+    "    \"Parameters, MACs at 64 px, state_dict size on disk and share of zeros in the convolutions\"\n",
+    "    model.eval()\n",
+    "    macs, params = tp.utils.count_ops_and_params(\n",
+    "        model, torch.randn(1, 3, 64, 64).to(next(model.parameters()).device))\n",
+    "    f = tmp/f\"{name}.pth\"; torch.save(model.state_dict(), f)\n",
+    "    w = [m.weight for m in model.modules() if isinstance(m, nn.Conv2d)]\n",
+    "    zeros = sum(int((x == 0).sum()) for x in w) / sum(x.numel() for x in w)\n",
+    "    stages.append(dict(stage=name, params=params, macs=macs, mb=f.stat().st_size/1e6,\n",
+    "                       zeros=zeros, acc=acc))\n",
+    "    print(f\"{name}: {params/1e6:.2f} M parameters, {macs/1e6:.0f} MMACs, \"\n",
+    "          f\"{f.stat().st_size/1e6:.1f} MB state_dict, {zeros:.1%} zeros in conv weights\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3e60472a",
+   "id": "wk008",
    "metadata": {},
    "source": [
-    "The first thing to do is to find a teacher, which can be any model, that preferrably performs well. We will chose **VGG19** for our demonstration. To make sure it performs better than our **VGG16** model, let's start from a pretrained version."
+    "A ResNet-18 with its ImageNet weights, fine-tuned for three epochs:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4be1f0a",
+   "id": "wk009",
    "metadata": {},
    "outputs": [
     {
@@ -492,24 +212,24 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>0</td>\n",
-       "      <td>0.941329</td>\n",
-       "      <td>0.353027</td>\n",
-       "      <td>0.896051</td>\n",
-       "      <td>00:06</td>\n",
+       "      <td>0.647689</td>\n",
+       "      <td>0.335134</td>\n",
+       "      <td>0.858593</td>\n",
+       "      <td>00:04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>1</td>\n",
-       "      <td>0.467530</td>\n",
-       "      <td>0.222822</td>\n",
-       "      <td>0.929936</td>\n",
-       "      <td>00:06</td>\n",
+       "      <td>0.336341</td>\n",
+       "      <td>0.254721</td>\n",
+       "      <td>0.893099</td>\n",
+       "      <td>00:04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>2</td>\n",
-       "      <td>0.443237</td>\n",
-       "      <td>0.213563</td>\n",
-       "      <td>0.935032</td>\n",
-       "      <td>00:06</td>\n",
+       "      <td>0.187006</td>\n",
+       "      <td>0.204517</td>\n",
+       "      <td>0.922192</td>\n",
+       "      <td>00:04</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
@@ -523,320 +243,66 @@
     }
    ],
    "source": [
-    "teacher = vision_learner(dls, models.vgg19_bn, metrics=[accuracy])\n",
-    "teacher.fit_one_cycle(3, 1e-4)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c3e84276",
-   "metadata": {},
-   "source": [
-    "Our teacher reaches **93.5%** accuracy (3670/3925, single run), so it is ready to take a student under its wing. Let's create our student model and train it with the **Knowledge Distillation** callback:"
+    "learn = vision_learner(dls, resnet18, metrics=accuracy, concat_pool=False)\n",
+    "learn.unfreeze()\n",
+    "learn.fit_one_cycle(3)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e0a3004",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<style>\n",
-       "    /* Turns off some styling */\n",
-       "    progress {\n",
-       "        /* gets rid of default border in Firefox and Opera. */\n",
-       "        border: none;\n",
-       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
-       "        background-size: auto;\n",
-       "    }\n",
-       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
-       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
-       "    }\n",
-       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
-       "        background: #F44336;\n",
-       "    }\n",
-       "</style>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: left;\">\n",
-       "      <th>epoch</th>\n",
-       "      <th>train_loss</th>\n",
-       "      <th>valid_loss</th>\n",
-       "      <th>accuracy</th>\n",
-       "      <th>time</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>0</td>\n",
-       "      <td>5.864407</td>\n",
-       "      <td>5.476386</td>\n",
-       "      <td>0.411465</td>\n",
-       "      <td>00:16</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>1</td>\n",
-       "      <td>4.312775</td>\n",
-       "      <td>5.342780</td>\n",
-       "      <td>0.501911</td>\n",
-       "      <td>00:16</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>2</td>\n",
-       "      <td>3.596799</td>\n",
-       "      <td>4.517756</td>\n",
-       "      <td>0.507006</td>\n",
-       "      <td>00:16</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>3</td>\n",
-       "      <td>3.102537</td>\n",
-       "      <td>3.239754</td>\n",
-       "      <td>0.644841</td>\n",
-       "      <td>00:16</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>4</td>\n",
-       "      <td>2.596609</td>\n",
-       "      <td>2.465116</td>\n",
-       "      <td>0.717707</td>\n",
-       "      <td>00:16</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>5</td>\n",
-       "      <td>2.418236</td>\n",
-       "      <td>2.516353</td>\n",
-       "      <td>0.702420</td>\n",
-       "      <td>00:16</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>6</td>\n",
-       "      <td>2.024942</td>\n",
-       "      <td>2.050347</td>\n",
-       "      <td>0.771465</td>\n",
-       "      <td>00:16</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>7</td>\n",
-       "      <td>1.850588</td>\n",
-       "      <td>1.784052</td>\n",
-       "      <td>0.803567</td>\n",
-       "      <td>00:16</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>8</td>\n",
-       "      <td>1.625190</td>\n",
-       "      <td>1.574969</td>\n",
-       "      <td>0.818089</td>\n",
-       "      <td>00:16</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>9</td>\n",
-       "      <td>1.565640</td>\n",
-       "      <td>1.578238</td>\n",
-       "      <td>0.813758</td>\n",
-       "      <td>00:16</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "student = Learner(dls, models.vgg16_bn(num_classes=10), metrics=[accuracy])\n",
-    "kd_cb = KnowledgeDistillationCallback(teacher.model, SoftTarget)\n",
-    "student.fit_one_cycle(10, 1e-4, cbs=kd_cb)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2dc60d7d",
-   "metadata": {},
-   "source": [
-    "With the teacher, the student ends at **81.38%** (3194/3925, Wilson 95% [80.13, 82.56]) against **81.17%** (3186/3925, [79.92, 82.36]) for the vanilla **VGG16** — one run each, and the two intervals overlap."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "139a138b",
-   "metadata": {},
-   "source": [
-    "With some experimentation, you could look for a model smaller than **VGG16** able to reach the same performance as our baseline. You can try to find it by yourself later, but for now let's continue with the next technique."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "89ddb841",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "422f2e6f",
-   "metadata": {},
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7c33622f",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4d6b17b3",
-   "metadata": {},
-   "source": [
-    "## **Sparsifying**"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0b87919d",
-   "metadata": {},
-   "source": [
-    "Now that we have a student model that is performing better than our baseline, we have some room to compress it. And we'll start by making the network sparse. As explained in a previous [article](https://nathanhubens.github.io/posts/deep%20learning/2020/05/22/pruning.html), there are many ways leading to a sparse network.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b065c8dc",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8a93883e",
-   "metadata": {},
-   "source": [
-    ":::{.callout-note}\n",
-    "\n",
-    "Usually, the process of making a network sparse is called Pruning. I prefer using the term Pruning when parameters are **actually** removed from the network, which we will do in the next section.\n",
-    "\n",
-    ":::"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ae2b665f",
-   "metadata": {},
-   "source": [
-    "<br>\n",
-    "\n",
-    "![](../imgs/schedules.png)\n",
-    "\n",
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9588836e",
-   "metadata": {},
-   "source": [
-    "By default, FasterAI uses the **Automated Gradual Pruning** paradigm as it removes parameters as the model trains and doesn't require to pretrain the model, so it is usually much faster. In FasterAI, this is also managed by using a callback, that will replace the *least important* parameters of your model by zeroes during the training. The callback has a wide variety of parameters to tune your **Sparsifying** operation, let's take a look at them:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a05e38ab",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "75bc8b14",
-   "metadata": {},
-   "source": [
-    "<blockquote>\n",
-    "    <pre><b><i>SparsifyCallback(learn, sparsity, granularity, context, criteria, schedule)</i></b></pre>\n",
-    "\n",
-    "<ul><i>\n",
-    "<li style=\"font-size:15px\"><b>sparsity</b>: the percentage of sparsity that you want in your network </li>\n",
-    "<li style=\"font-size:15px\"><b>granularity</b>: on what granularity you want the sparsification to be operated</li>\n",
-    "<li style=\"font-size:15px\"><b>context</b>: either <code>local</code> or <code>global</code>, will affect the selection of parameters to be choosen in each layer independently (<code>local</code>) or on the whole network (<code>global</code>).</li>\n",
-    "<li style=\"font-size:15px\"><b>criteria</b>: the criteria used to select which parameters to remove (currently supported: <code>l1</code>, <code>taylor</code>)</li>\n",
-    "<li style=\"font-size:15px\"><b>schedule</b>: which schedule you want to follow for the sparsification (currently supported: <a href=\"https://docs.fast.ai/callback.html#Annealing-functions\">any scheduling function of fastai</a>, i.e <code>linear</code>, <code>cosine</code>, ... and <code>gradual</code>, common schedules such as One-Shot, Iterative or <a href=\"https://openreview.net/pdf?id=Sy1iIDkPM\">Automated Gradual</a>)</li>\n",
-    "</i></ul>\n",
-    "</blockquote>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "144f91b4",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f6fe7ef5",
-   "metadata": {},
-   "source": [
-    "**But let's come back to our example!**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "594743cd",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#| include: false\n",
-    "from fasterai.sparse.all import *"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "271dd40c",
-   "metadata": {},
-   "source": [
-    "Here, we will make our network **50%** sparse, removing entire **filters**, compared **globally** across the network and selected by weight magnitude (`large_final`). We will train with a learning rate a bit smaller to be gentle with our network because it has already been trained. The **schedule** selected is cosinusoidal, so the sparsification starts and ends quite slowly."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "58273b0a",
+   "id": "wk010",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Pruning of filter until a sparsity of 50%\n",
+      "baseline: 92.22% (1363/1478), Wilson 95% [90.74%, 93.48%]\n",
+      "baseline: 11.44 M parameters, 149 MMACs, 45.9 MB state_dict, 0.0% zeros in conv weights\n"
+     ]
+    }
+   ],
+   "source": [
+    "record(\"baseline\", learn.model, report(learn, \"baseline\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wk011",
+   "metadata": {},
+   "source": [
+    "`concat_pool=False` gives the head a plain average pool: the exporter of step 5 has no translation\n",
+    "for adaptive max pooling."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wk012",
+   "metadata": {},
+   "source": [
+    "## 2. Sparsify\n",
+    "\n",
+    "`SparsifyCallback` zeroes weights while training continues:\n",
+    "\n",
+    "- **`sparsity=0.5`** - the fraction of weights to zero\n",
+    "- **`granularity='weight'`** - individual weights, the model keeps its shape\n",
+    "- **`context='local'`** - each layer on its own\n",
+    "- **`criteria=large_final`** - keep the largest final magnitudes\n",
+    "- **`schedule=one_cycle`** - how the sparsity grows to its target"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "wk013",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsifying weight until a sparsity of 50.00%\n",
       "Saving Weights at epoch 0\n"
      ]
     },
@@ -883,73 +349,38 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>0</td>\n",
-       "      <td>0.590607</td>\n",
-       "      <td>0.572063</td>\n",
-       "      <td>0.820637</td>\n",
-       "      <td>00:11</td>\n",
+       "      <td>0.179395</td>\n",
+       "      <td>0.468179</td>\n",
+       "      <td>0.849120</td>\n",
+       "      <td>00:07</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>1</td>\n",
-       "      <td>0.621573</td>\n",
-       "      <td>0.576351</td>\n",
-       "      <td>0.814522</td>\n",
-       "      <td>00:11</td>\n",
+       "      <td>0.280292</td>\n",
+       "      <td>0.729538</td>\n",
+       "      <td>0.772666</td>\n",
+       "      <td>00:07</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>2</td>\n",
-       "      <td>0.569623</td>\n",
-       "      <td>0.564671</td>\n",
-       "      <td>0.812229</td>\n",
-       "      <td>00:11</td>\n",
+       "      <td>0.214267</td>\n",
+       "      <td>0.196754</td>\n",
+       "      <td>0.918809</td>\n",
+       "      <td>00:08</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>3</td>\n",
-       "      <td>0.575295</td>\n",
-       "      <td>0.585963</td>\n",
-       "      <td>0.813503</td>\n",
-       "      <td>00:11</td>\n",
+       "      <td>0.123649</td>\n",
+       "      <td>0.170752</td>\n",
+       "      <td>0.934371</td>\n",
+       "      <td>00:06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>4</td>\n",
-       "      <td>0.557072</td>\n",
-       "      <td>0.572918</td>\n",
-       "      <td>0.818599</td>\n",
-       "      <td>00:11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>5</td>\n",
-       "      <td>0.565852</td>\n",
-       "      <td>0.592840</td>\n",
-       "      <td>0.812229</td>\n",
-       "      <td>00:11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>6</td>\n",
-       "      <td>0.621907</td>\n",
-       "      <td>0.611757</td>\n",
-       "      <td>0.807389</td>\n",
-       "      <td>00:11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>7</td>\n",
-       "      <td>0.656858</td>\n",
-       "      <td>0.608958</td>\n",
-       "      <td>0.802803</td>\n",
-       "      <td>00:11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>8</td>\n",
-       "      <td>0.624567</td>\n",
-       "      <td>0.648065</td>\n",
-       "      <td>0.788535</td>\n",
-       "      <td>00:11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>9</td>\n",
-       "      <td>0.620338</td>\n",
-       "      <td>0.608264</td>\n",
-       "      <td>0.800255</td>\n",
-       "      <td>00:11</td>\n",
+       "      <td>0.073424</td>\n",
+       "      <td>0.160134</td>\n",
+       "      <td>0.938430</td>\n",
+       "      <td>00:07</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
@@ -965,846 +396,166 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sparsity at the end of epoch 0: 1.22%\n",
-      "Sparsity at the end of epoch 1: 4.77%\n",
-      "Sparsity at the end of epoch 2: 10.31%\n",
-      "Sparsity at the end of epoch 3: 17.27%\n",
-      "Sparsity at the end of epoch 4: 25.00%\n",
-      "Sparsity at the end of epoch 5: 32.73%\n",
-      "Sparsity at the end of epoch 6: 39.69%\n",
-      "Sparsity at the end of epoch 7: 45.23%\n",
-      "Sparsity at the end of epoch 8: 48.78%\n",
-      "Sparsity at the end of epoch 9: 50.00%\n",
+      "Sparsity at the end of epoch 0: 1.96%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsity at the end of epoch 1: 20.07%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsity at the end of epoch 2: 45.86%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsity at the end of epoch 3: 49.74%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsity at the end of epoch 4: 50.00%\n",
       "Final Sparsity: 50.00%\n",
       "\n",
       "Sparsity Report:\n",
       "--------------------------------------------------------------------------------\n",
       "Layer                          Type            Params     Zeros      Sparsity  \n",
       "--------------------------------------------------------------------------------\n",
-      "features.0                     Conv2d          1,728      0              0.00%\n",
-      "features.3                     Conv2d          36,864     0              0.00%\n",
-      "features.7                     Conv2d          73,728     0              0.00%\n",
-      "features.10                    Conv2d          147,456    0              0.00%\n",
-      "features.14                    Conv2d          294,912    0              0.00%\n",
-      "features.17                    Conv2d          589,824    0              0.00%\n",
-      "features.20                    Conv2d          589,824    0              0.00%\n",
-      "features.24                    Conv2d          1,179,648  755,712       64.06%\n",
-      "features.27                    Conv2d          2,359,296  1,700,352     72.07%\n",
-      "features.30                    Conv2d          2,359,296  1,714,176     72.66%\n",
-      "features.34                    Conv2d          2,359,296  1,612,800     68.36%\n",
-      "features.37                    Conv2d          2,359,296  1,529,856     64.84%\n",
-      "features.40                    Conv2d          2,359,296  1,663,488     70.51%\n",
+      "0.0                            Conv2d          9,408      4,702         49.98%\n",
+      "0.4.0.conv1                    Conv2d          36,864     18,430        49.99%\n",
+      "0.4.0.conv2                    Conv2d          36,864     18,430        49.99%\n",
+      "0.4.1.conv1                    Conv2d          36,864     18,430        49.99%\n",
+      "0.4.1.conv2                    Conv2d          36,864     18,430        49.99%\n",
+      "0.5.0.conv1                    Conv2d          73,728     36,862        50.00%\n",
+      "0.5.0.conv2                    Conv2d          147,456    73,726        50.00%\n",
+      "0.5.0.downsample.0             Conv2d          8,192      4,094         49.98%\n",
+      "0.5.1.conv1                    Conv2d          147,456    73,726        50.00%\n",
+      "0.5.1.conv2                    Conv2d          147,456    73,726        50.00%\n",
+      "0.6.0.conv1                    Conv2d          294,912    147,453       50.00%\n",
+      "0.6.0.conv2                    Conv2d          589,824    294,908       50.00%\n",
+      "0.6.0.downsample.0             Conv2d          32,768     16,382        49.99%\n",
+      "0.6.1.conv1                    Conv2d          589,824    294,908       50.00%\n",
+      "0.6.1.conv2                    Conv2d          589,824    294,908       50.00%\n",
+      "0.7.0.conv1                    Conv2d          1,179,648  589,817       50.00%\n",
+      "0.7.0.conv2                    Conv2d          2,359,296  1,179,635     50.00%\n",
+      "0.7.0.downsample.0             Conv2d          131,072    65,534        50.00%\n",
+      "0.7.1.conv1                    Conv2d          2,359,296  1,179,635     50.00%\n",
+      "0.7.1.conv2                    Conv2d          2,359,296  1,179,635     50.00%\n",
       "--------------------------------------------------------------------------------\n",
-      "Overall                        all             14,710,464 8,976,384     61.02%\n"
+      "Overall                        all             11,166,912 5,583,371     50.00%\n"
      ]
     }
    ],
    "source": [
-    "sp_cb = SparsifyCallback(sparsity=50, granularity='filter', context='global', criteria=large_final, schedule=cos)\n",
-    "student.fit(10, 1e-5, cbs=sp_cb)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "07bffc84",
-   "metadata": {},
-   "source": [
-    "Our network now has **50%** of its filters composed entirely of zeroes — 61.02% of the convolution parameters, because the globally selected filters came from the widest layers (the report above shows the early ones untouched)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5cce8e37",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9511cfb0",
-   "metadata": {},
-   "source": [
-    "Let's now see how much we gained in terms of speed. Because we removed **50%** of convolution filters, we should expect crazy speed-up right ? "
+    "sp_cb = SparsifyCallback(sparsity=0.5, granularity='weight', context='local',\n",
+    "                         criteria=large_final, schedule=one_cycle)\n",
+    "learn.fit_one_cycle(5, cbs=sp_cb)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86f940d9-8bad-49de-ba48-8b40582a822a",
+   "id": "wk014",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Inference Speed: 83.03ms\n"
+      "sparsified: 93.84% (1387/1478), Wilson 95% [92.50%, 94.96%]\n",
+      "sparsified: 11.44 M parameters, 149 MMACs, 45.9 MB state_dict, 50.0% zeros in conv weights\n"
      ]
     }
    ],
    "source": [
-    "print(f'Inference Speed: {evaluate_cpu_speed(student.model, x[0][None])[0]:.2f}ms')"
+    "record(\"sparsified\", learn.model, report(learn, \"sparsified\"))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "c6dce1ad-c470-4419-ba1d-986a76220601",
+   "id": "wk015",
    "metadata": {},
    "source": [
-    "Well actually, no. We didn't remove any parameters, we just replaced some by zeroes, remember? The amount of parameters is still the same:"
+    "Half of the convolution weights are zero and nothing else moved: same parameter count, same MACs,\n",
+    "same file on disk. A dense format stores a zero like any other number."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wk016",
+   "metadata": {},
+   "source": [
+    "## 3. Prune\n",
+    "\n",
+    "`Pruner` removes the filters themselves. It runs once, outside the training loop, and the fit that\n",
+    "follows retrains what is left."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2967a8a1",
+   "id": "wk017",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Model Size: 537.30 MB (disk), 134309962 parameters\n"
-     ]
-    }
-   ],
-   "source": [
-    "num_parameters = get_num_parameters(student.model)\n",
-    "disk_size = get_model_size(student.model)\n",
-    "print(f\"Model Size: {disk_size / 1e6:.2f} MB (disk), {num_parameters} parameters\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7d4be3ee",
-   "metadata": {},
-   "source": [
-    "Which leads us to the next section."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7004632d",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4aa03dcd",
-   "metadata": {},
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cbb8e603",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "61dc00ce",
-   "metadata": {},
-   "source": [
-    "## **Pruning**"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7cf28720",
-   "metadata": {},
-   "source": [
-    "Why don't we see any acceleration even though we removed half of the parameters? That's because natively, our **GPU** does not know that our matrices are sparse and thus isn't able to accelerate the computation. The easiest work around, is to **physically** remove the parameters we zeroed-out. But this operation requires to change the architecture of the network. \n",
-    "\n",
-    "This pruning only works if we remove entire filters as it is the only case where we can change the architecture accordingly. Hopefully, sparse computations will [soon be available](https://pytorch.org/docs/stable/sparse.html) on common deep learning librairies so this section will become useless in the future.\n",
-    "\n",
-    "<br>\n",
-    "\n",
-    "Here is what it looks like with fasterai:\n",
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "33454908",
-   "metadata": {},
-   "source": [
-    "![](../imgs/pruning_filters.png)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c1ff5626",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "de369176",
-   "metadata": {},
-   "source": [
-    "<blockquote>\n",
-    "    <pre><b><i>PruneCallback(learn, sparsity, context, criteria, schedule)</i></b></pre>\n",
-    "\n",
-    "<ul><i>\n",
-    "<li style=\"font-size:15px\"><b>sparsity</b>: the percentage of sparsity that you want in your network </li>\n",
-    "<li style=\"font-size:15px\"><b>context</b>: either <code>local</code> or <code>global</code>, will affect the selection of parameters to be choosen in each layer independently (<code>local</code>) or on the whole network (<code>global</code>).</li>\n",
-    "<li style=\"font-size:15px\"><b>criteria</b>: the criteria used to select which parameters to remove (currently supported: <code>l1</code>, <code>taylor</code>)</li>\n",
-    "<li style=\"font-size:15px\"><b>schedule</b>: which schedule you want to follow for the sparsification (currently supported: <a href=\"https://docs.fast.ai/callback.html#Annealing-functions\">any scheduling function of fastai</a>, i.e <code>linear</code>, <code>cosine</code>, ... and <code>gradual</code>, common schedules such as One-Shot, Iterative or <a href=\"https://openreview.net/pdf?id=Sy1iIDkPM\">Automated Gradual</a>)</li>\n",
-    "</i></ul>\n",
-    "</blockquote>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "97138db9",
-   "metadata": {},
-   "source": [
-    "So in the case of our example, it gives: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "79a85c80",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from fasterai.prune.all import *"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1e0f467f",
-   "metadata": {},
-   "source": [
-    "Let's now see what our model is capable of now:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b0cdfe64",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Ignoring output layer: classifier.6\n",
+      "Ignoring output layer: 1.8\n",
       "Total ignored layers: 1\n"
      ]
     },
     {
-     "data": {
-      "text/html": [
-       "\n",
-       "<style>\n",
-       "    /* Turns off some styling */\n",
-       "    progress {\n",
-       "        /* gets rid of default border in Firefox and Opera. */\n",
-       "        border: none;\n",
-       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
-       "        background-size: auto;\n",
-       "    }\n",
-       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
-       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
-       "    }\n",
-       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
-       "        background: #F44336;\n",
-       "    }\n",
-       "</style>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pruned: 5.59 M parameters, 74 MMACs, 22.4 MB state_dict, 48.8% zeros in conv weights\n"
+     ]
+    }
+   ],
+   "source": [
+    "pruner = Pruner(learn.model, 0.3, 'local', large_final,\n",
+    "                example_inputs=torch.randn(1, 3, 64, 64).to(default_device()))\n",
+    "pruner.prune_model()\n",
+    "\n",
+    "record(\"pruned\", learn.model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wk018",
+   "metadata": {},
+   "source": [
+    "Pruning drops the share of zeros a little: `large_final` removes the lowest-magnitude filters, which\n",
+    "hold more than their share of zeros. The recovery fit re-applies `SparsifyCallback`, so the model ends\n",
+    "it at 50 % zeros again — its `one_cycle` schedule ramps the target back up from 0, which is why the\n",
+    "intermediate epochs print less: a fresh mask, not the one from step 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "wk019",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsifying weight until a sparsity of 50.00%\n",
+      "Saving Weights at epoch 0\n"
+     ]
     },
-    {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: left;\">\n",
-       "      <th>epoch</th>\n",
-       "      <th>train_loss</th>\n",
-       "      <th>valid_loss</th>\n",
-       "      <th>accuracy</th>\n",
-       "      <th>time</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>0</td>\n",
-       "      <td>0.600658</td>\n",
-       "      <td>0.603180</td>\n",
-       "      <td>0.802293</td>\n",
-       "      <td>01:04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>1</td>\n",
-       "      <td>0.606881</td>\n",
-       "      <td>0.634970</td>\n",
-       "      <td>0.804076</td>\n",
-       "      <td>01:22</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>2</td>\n",
-       "      <td>0.827685</td>\n",
-       "      <td>0.815733</td>\n",
-       "      <td>0.803057</td>\n",
-       "      <td>01:00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>3</td>\n",
-       "      <td>0.873774</td>\n",
-       "      <td>0.878398</td>\n",
-       "      <td>0.803567</td>\n",
-       "      <td>00:57</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>4</td>\n",
-       "      <td>0.889905</td>\n",
-       "      <td>0.876898</td>\n",
-       "      <td>0.803312</td>\n",
-       "      <td>00:56</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Sparsity at the end of epoch 0: 1.94%\n",
-      "Sparsity at the end of epoch 1: 19.96%\n",
-      "Sparsity at the end of epoch 2: 45.82%\n",
-      "Sparsity at the end of epoch 3: 49.74%\n",
-      "Sparsity at the end of epoch 4: 50.00%\n"
-     ]
-    }
-   ],
-   "source": [
-    "pr_cb = PruneCallback(pruning_ratio=50, context='global', criteria=large_final, schedule=one_cycle)\n",
-    "student.fit(5, 1e-5, cbs=pr_cb)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c3d9db2b",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model Size: 148.86 MB (disk), 37200724 parameters\n"
-     ]
-    }
-   ],
-   "source": [
-    "num_parameters = get_num_parameters(student.model)\n",
-    "disk_size = get_model_size(student.model)\n",
-    "print(f\"Model Size: {disk_size / 1e6:.2f} MB (disk), {num_parameters} parameters\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4a27e756",
-   "metadata": {},
-   "source": [
-    "And in terms of speed:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8b321078",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inference Speed: 53.93ms\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(f'Inference Speed: {evaluate_cpu_speed(student.model, x[0][None])[0]:.2f}ms')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "00a98866",
-   "metadata": {},
-   "source": [
-    "Yay ! Now we can talk ! The accuracy after pruning is the one printed by the fine-tuning run above (80.33%, 3153/3925, single run) — no separate check is run here."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "95e346f8",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8829ab1a",
-   "metadata": {},
-   "source": [
-    "And there is actually more that we can do ! Let's keep going ! "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9ec57c8b",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "523fbc65",
-   "metadata": {},
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2df2f6f3",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3d0c0ab6",
-   "metadata": {},
-   "source": [
-    "## **Batch Normalization Folding**"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8367fe86",
-   "metadata": {},
-   "source": [
-    "**Batch Normalization Folding** is a really easy to implement and straightforward idea. The gist is that batch normalization is nothing more than a normalization of the input data at each layer. Moreover, at inference time, the batch statistics used for this normalization are fixed. We can thus incorporate the normalization process directly in the convolution by changing its weights and completely remove the batch normalization layers, which is a gain both in terms of parameters and in terms of computations. For a more in-depth explaination, see this [blog post](https://nathanhubens.github.io/posts/deep%20learning/2020/04/20/BN.html). \n",
-    "\n",
-    "This is how to use it with FasterAI:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bab9080d",
-   "metadata": {},
-   "source": [
-    "<blockquote>\n",
-    "<pre><b><i>bn_folder = BN_Folder()\n",
-    "bn_folder.fold(learn.model))</i></b></pre>\n",
-    "<p style=\"font-size: 15px\"><i>\n",
-    "Again, you only need to pass your model and FasterAI takes care of the rest. For models built using the nn.Sequential, you don't need to change anything. For others, if you want to see speedup and compression, you actually need to subclass your model to remove the batch norm from the parameters and from the <code>forward</code> method of your network.\n",
-    "</i></p>\n",
-    "</blockquote>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1825f7f8",
-   "metadata": {},
-   "source": [
-    ":::{.callout-note}\n",
-    "\n",
-    "This operation should also be lossless as it redefines the convolution to take batch norm into account and is thus equivalent.\n",
-    "\n",
-    ":::"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "de3428ae",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fe83ec7e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from fasterai.misc.bn_folding import *"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "47386fcb",
-   "metadata": {},
-   "source": [
-    "Let's do this with our model ! "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9700105a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bn_f = BN_Folder()\n",
-    "folded_model = bn_f.fold(student.model)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "75ac1b36",
-   "metadata": {},
-   "source": [
-    "The parameters drop is generally not that significant, especially in a network such as **VGG** where almost all parameters are contained in the FC layers but, hey, any gain is good to take."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "103c4713",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model Size: 148.79 MB (disk), 37194430 parameters\n"
-     ]
-    }
-   ],
-   "source": [
-    "num_parameters = get_num_parameters(folded_model)\n",
-    "disk_size = get_model_size(folded_model)\n",
-    "print(f\"Model Size: {disk_size / 1e6:.2f} MB (disk), {num_parameters} parameters\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a1986747",
-   "metadata": {},
-   "source": [
-    "The batch normalization layers are gone, but the inference time does not improve: 54.40 ms against 53.93 ms before."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "56577a35",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inference Speed: 54.40ms\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(f'Inference Speed: {evaluate_cpu_speed(folded_model, x[0][None])[0]:.2f}ms')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c4081c08",
-   "metadata": {},
-   "source": [
-    "Again, let's double check that we didn't mess up somewhere:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d1aa8b13",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<style>\n",
-       "    /* Turns off some styling */\n",
-       "    progress {\n",
-       "        /* gets rid of default border in Firefox and Opera. */\n",
-       "        border: none;\n",
-       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
-       "        background-size: auto;\n",
-       "    }\n",
-       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
-       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
-       "    }\n",
-       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
-       "        background: #F44336;\n",
-       "    }\n",
-       "</style>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[0.8769694566726685, 0.8033121228218079]"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "folded_learner = Learner(dls, folded_model, metrics=[accuracy])\n",
-    "folded_learner.validate()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9f9893ca",
-   "metadata": {},
-   "source": [
-    "And we're still not done yet ! As we know for **VGG16**, most of the parameters are comprised in the fully-connected layers so there should be something that we can do about it, right ? "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "67d836c2",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "37add588",
-   "metadata": {},
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "56f295e9",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1c617c7d",
-   "metadata": {},
-   "source": [
-    "## **FC Layers Factorization**"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a31eed16",
-   "metadata": {},
-   "source": [
-    "We can indeed, factorize our big fully-connected layers and replace them by an approximation of two smaller layers. The idea is to make an **SVD** decomposition of the weight matrix, which will express the original matrix in a product of 3 matrices: $U \\Sigma V^T$. With $\\Sigma$ being a diagonal matrix with non-negative values along its diagonal (the singular values). We then define a value $k$ of singular values to keep and modify matrices $U$ and $V^T$ accordingly. The resulting will be an approximation of the initial matrix."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "46b47a5f",
-   "metadata": {},
-   "source": [
-    "![](../imgs/svd.png)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6f3c682d",
-   "metadata": {},
-   "source": [
-    "In FasterAI, to decompose the fully-connected layers of your model, here is what you need to do:\n",
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "22633913",
-   "metadata": {},
-   "source": [
-    "<blockquote>\n",
-    "<pre><b><i>FCD = FCDecomposer()\n",
-    "decomposed_model = FCD.decompose(model, percent_removed)</i></b></pre>\n",
-    "<p style=\"font-size: 15px\"><i>\n",
-    "    The <code>percent_removed</code> corresponds to the percentage of singular values removed (<i>k</i> value above).\n",
-    "</i></p>\n",
-    "</blockquote>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3a7f923f",
-   "metadata": {},
-   "source": [
-    ":::{.callout-note}\n",
-    "\n",
-    "This time, the decomposition is not exact, so we expect a drop in performance afterwards and further retraining will be needed.\n",
-    "\n",
-    ":::"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "81c05749",
-   "metadata": {},
-   "source": [
-    "Which gives with our example, if we only want to keep half of them:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d7b20be4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from fasterai.misc.fc_decomposer import *"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f155ed57",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fc_decomposer = FC_Decomposer()\n",
-    "decomposed_model = fc_decomposer.decompose(folded_learner.model, percent_removed=0.5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "62d14c98",
-   "metadata": {},
-   "source": [
-    "How many parameters do we have now ?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c7c4625a",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model Size: 98.82 MB (disk), 22936504 parameters\n"
-     ]
-    }
-   ],
-   "source": [
-    "num_parameters = get_num_parameters(decomposed_model)\n",
-    "disk_size = get_model_size(decomposed_model)\n",
-    "print(f\"Model Size: {disk_size / 1e6:.2f} MB (disk), {num_parameters} parameters\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c717dba4",
-   "metadata": {},
-   "source": [
-    "And how much time did we gain ? "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1b7a792a",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inference Speed: 51.96ms\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(f'Inference Speed: {evaluate_cpu_speed(decomposed_model, x[0][None])[0]:.2f}ms')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dc53ecb2",
-   "metadata": {},
-   "source": [
-    "The decomposed network runs at **51.96 ms** against **54.40 ms** before — two timings taken one after another; this page does not measure run-to-run variance (the one same-model repeat it contains, 29.35 vs 29.57 ms, differs by 0.22 ms). It has **14.3M** fewer parameters (37,194,430 → 22,936,504)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "586f5299",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "de463984",
-   "metadata": {},
-   "source": [
-    "However, this technique is an approximation so it is not lossless, so we should retrain our network a bit to recover its performance."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d17d2ded",
-   "metadata": {},
-   "outputs": [
     {
      "data": {
       "text/html": [
@@ -1848,138 +599,27 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>0</td>\n",
-       "      <td>0.912265</td>\n",
-       "      <td>0.920241</td>\n",
-       "      <td>0.714140</td>\n",
-       "      <td>00:06</td>\n",
+       "      <td>0.272020</td>\n",
+       "      <td>1.469996</td>\n",
+       "      <td>0.773342</td>\n",
+       "      <td>00:05</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>1</td>\n",
-       "      <td>0.747366</td>\n",
-       "      <td>0.758958</td>\n",
-       "      <td>0.774267</td>\n",
-       "      <td>00:06</td>\n",
+       "      <td>0.188387</td>\n",
+       "      <td>0.222212</td>\n",
+       "      <td>0.911367</td>\n",
+       "      <td>00:04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>2</td>\n",
-       "      <td>0.686810</td>\n",
-       "      <td>0.702474</td>\n",
-       "      <td>0.789809</td>\n",
-       "      <td>00:07</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>3</td>\n",
-       "      <td>0.653998</td>\n",
-       "      <td>0.683656</td>\n",
-       "      <td>0.800000</td>\n",
-       "      <td>00:06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>4</td>\n",
-       "      <td>0.611083</td>\n",
-       "      <td>0.677875</td>\n",
-       "      <td>0.800510</td>\n",
+       "      <td>0.106858</td>\n",
+       "      <td>0.214357</td>\n",
+       "      <td>0.920162</td>\n",
        "      <td>00:06</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "final_learner = Learner(dls, decomposed_model, metrics=[accuracy])\n",
-    "final_learner.fit_one_cycle(5, 1e-5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e7b5280d",
-   "metadata": {},
-   "source": [
-    "This operation is usually less useful for more recent architectures as they usually do not have that many parameters in their fully-connected layers."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4750f78f",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ec8a6e58",
-   "metadata": {},
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b3e0ae5b",
-   "metadata": {},
-   "source": [
-    "## Quantization"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a27fa530",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from fasterai.quantize.all import *"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5f17cb74-360e-42de-92ee-55d56ecdede9",
-   "metadata": {},
-   "source": [
-    "Now that we have removed every superfluous parameter that we could, we can still continue to compress our model. A common way to do so is now to reduce the precision of each parameter in the network, making it considerably smaller. Such an approach is called **Quantization** and won't affect the total number of parameter but will make each one of them smaller to store, on top of making computations faster."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d732d78a-2613-4e4b-88a2-947a5acc984a",
-   "metadata": {},
-   "source": [
-    "In **FasterAI**, quantization can be done in a static way, i.e. apply quantization to the model, also called Post-Training Quantization. It also can be applied dynamically during the training, also called Quantization-Aware Training."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1938555c",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<style>\n",
-       "    /* Turns off some styling */\n",
-       "    progress {\n",
-       "        /* gets rid of default border in Firefox and Opera. */\n",
-       "        border: none;\n",
-       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
-       "        background-size: auto;\n",
-       "    }\n",
-       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
-       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
-       "    }\n",
-       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
-       "        background: #F44336;\n",
-       "    }\n",
-       "</style>\n"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -1989,278 +629,403 @@
      "output_type": "display_data"
     },
     {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: left;\">\n",
-       "      <th>epoch</th>\n",
-       "      <th>train_loss</th>\n",
-       "      <th>valid_loss</th>\n",
-       "      <th>accuracy</th>\n",
-       "      <th>time</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>0</td>\n",
-       "      <td>0.673032</td>\n",
-       "      <td>0.713057</td>\n",
-       "      <td>0.784968</td>\n",
-       "      <td>00:09</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>1</td>\n",
-       "      <td>0.659847</td>\n",
-       "      <td>0.752605</td>\n",
-       "      <td>0.785733</td>\n",
-       "      <td>00:09</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>2</td>\n",
-       "      <td>0.635560</td>\n",
-       "      <td>0.689459</td>\n",
-       "      <td>0.795159</td>\n",
-       "      <td>00:09</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>3</td>\n",
-       "      <td>0.613627</td>\n",
-       "      <td>0.643876</td>\n",
-       "      <td>0.812739</td>\n",
-       "      <td>00:09</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>4</td>\n",
-       "      <td>0.573815</td>\n",
-       "      <td>0.643116</td>\n",
-       "      <td>0.809172</td>\n",
-       "      <td>00:09</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsity at the end of epoch 0: 10.40%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsity at the end of epoch 1: 48.30%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsity at the end of epoch 2: 50.00%\n",
+      "Final Sparsity: 50.00%\n",
+      "\n",
+      "Sparsity Report:\n",
+      "--------------------------------------------------------------------------------\n",
+      "Layer                          Type            Params     Zeros      Sparsity  \n",
+      "--------------------------------------------------------------------------------\n",
+      "0.0                            Conv2d          6,468      3,232         49.97%\n",
+      "0.4.0.conv1                    Conv2d          17,424     8,710         49.99%\n",
+      "0.4.0.conv2                    Conv2d          17,424     8,710         49.99%\n",
+      "0.4.1.conv1                    Conv2d          17,424     8,710         49.99%\n",
+      "0.4.1.conv2                    Conv2d          17,424     8,710         49.99%\n",
+      "0.5.0.conv1                    Conv2d          35,244     17,620        49.99%\n",
+      "0.5.0.conv2                    Conv2d          71,289     35,642        50.00%\n",
+      "0.5.0.downsample.0             Conv2d          3,916      1,956         49.95%\n",
+      "0.5.1.conv1                    Conv2d          71,289     35,642        50.00%\n",
+      "0.5.1.conv2                    Conv2d          71,289     35,642        50.00%\n",
+      "0.6.0.conv1                    Conv2d          143,379    71,687        50.00%\n",
+      "0.6.0.conv2                    Conv2d          288,369    144,180       50.00%\n",
+      "0.6.0.downsample.0             Conv2d          15,931     7,964         49.99%\n",
+      "0.6.1.conv1                    Conv2d          288,369    144,180       50.00%\n",
+      "0.6.1.conv2                    Conv2d          288,369    144,180       50.00%\n",
+      "0.7.0.conv1                    Conv2d          576,738    288,362       50.00%\n",
+      "0.7.0.conv2                    Conv2d          1,153,476  576,725       50.00%\n",
+      "0.7.0.downsample.0             Conv2d          64,082     32,039        50.00%\n",
+      "0.7.1.conv1                    Conv2d          1,153,476  576,725       50.00%\n",
+      "0.7.1.conv2                    Conv2d          1,153,476  576,725       50.00%\n",
+      "--------------------------------------------------------------------------------\n",
+      "Overall                        all             5,454,856  2,727,341     50.00%\n"
+     ]
     }
    ],
    "source": [
-    "final_learner.fit_one_cycle(5, 1e-5, cbs=QuantizeCallback())"
+    "sp_cb = SparsifyCallback(sparsity=0.5, granularity='weight', context='local',\n",
+    "                         criteria=large_final, schedule=one_cycle)\n",
+    "learn.fit_one_cycle(3, reset_opt=True, cbs=sp_cb)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d390878b-4fab-4447-9fd8-77bf57a0dea9",
+   "id": "wk020",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Inference Speed: 29.35ms\n"
+      "pruned + recovery: 92.02% (1360/1478), Wilson 95% [90.52%, 93.29%]\n",
+      "pruned + recovery: 5.59 M parameters, 74 MMACs, 22.4 MB state_dict, 50.0% zeros in conv weights\n"
      ]
     }
    ],
    "source": [
-    "print(f'Inference Speed: {evaluate_cpu_speed(final_learner.model, x[0][None])[0]:.2f}ms')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8ad298b5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#| include: false\n",
-    "def count_parameters_quantized(model):\n",
-    "    total_params = 0\n",
-    "    for module in model.modules():\n",
-    "        if isinstance(module, torch.nn.modules.conv.Conv2d) or \\\n",
-    "           isinstance(module, torch.nn.Linear) or \\\n",
-    "           isinstance(module, torch.ao.nn.quantized.modules.conv.Conv2d) or \\\n",
-    "           isinstance(module, torch.ao.nn.quantized.modules.linear.Linear):\n",
-    "            \n",
-    "            total_params += module.weight().numel()\n",
-    "            \n",
-    "            if module.bias() is not None:\n",
-    "                total_params += module.bias().numel()\n",
-    "    return total_params"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2d3d556d-24db-40d9-a5ae-21f73306a97e",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model Size: 23.11 MB (disk), 22,936,504 parameters\n"
-     ]
-    }
-   ],
-   "source": [
-    "num_parameters = count_parameters_quantized(final_learner.model)\n",
-    "disk_size = get_model_size(final_learner.model)\n",
-    "print(f\"Model Size: {disk_size / 1e6:.2f} MB (disk), {num_parameters:,} parameters\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "be0c61cd-edc8-4e0c-9d30-e82a10193882",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inference Speed: 29.57ms\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(f'Inference Speed: {evaluate_cpu_speed(final_learner.model, x[0][None])[0]:.2f}ms')"
+    "record(\"pruned + recovery\", learn.model, report(learn, \"pruned + recovery\"))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "512b7f18",
+   "id": "wk021",
    "metadata": {},
    "source": [
-    "---"
+    "Removing filters halves the parameter count, the MACs and the `state_dict`, and the model ends the\n",
+    "recovery fit at 50 % zeros again. The accuracy after recovery sits inside the baseline's interval."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f0d45e00-3c21-4ea2-98c2-aaf07ef9741f",
+   "id": "wk022",
    "metadata": {},
    "source": [
-    "## Extra Acceleration"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "35302d58-f9d0-489f-8c0a-46059c5c32d8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from fasterai.misc.cpu_optimizer import optimize_for_cpu"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ba0241dd-34c5-4dff-8821-7ff583e835da",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "final_model = optimize_for_cpu(final_learner.model, x[0][None].cpu(), backend='trace')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cedc8685-a358-464c-ad76-14c8e5985cfb",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inference Speed: 28.94ms\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(f'Inference Speed: {evaluate_cpu_speed(final_model, x[0][None])[0]:.2f}ms')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "wt-size-note",
-   "metadata": {},
-   "source": [
-    "The size of this accelerated model is not reported: in this run `get_model_size` and `get_num_parameters` returned `0.00 MB (disk), 0 parameters` for the optimized module, which is a sentinel and not a measurement. The last measured size is the 23.11 MB of the quantized model above."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3cf8d75b-a6b6-4e6e-b8a3-8bd98c306511",
-   "metadata": {},
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "158ee7dc",
-   "metadata": {},
-   "source": [
-    "So to recap, we saw in this article how to use fasterai to: <br>\n",
-    "1. Make a student model learn from a teacher model (**Knowledge Distillation**) <br>\n",
-    "2. Make our network sparse (**Sparsifying**) <br> \n",
-    "3. Optionally physically remove the zero-filters (**Pruning**) <br>\n",
-    "4. Remove the batch norm layers (**Batch Normalization Folding**) <br> \n",
-    "5. Approximate our big fully-connected layers by smaller ones (**Fully-Connected Layers Factorization**) <br>\n",
-    "6. Quantize the model to reduce the precision of the weights (**Quantization**) <br>\n",
-    "7. Extra acceleration techniques to further optimize the speed of our network\n",
-    ""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9374891a",
-   "metadata": {},
-   "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "26149076",
-   "metadata": {},
-   "source": [
-    "In this run, the **VGG16** model went from **537.30 MB** on disk down to **23.11 MB** after quantization (23x smaller). Inference went from **80.86 ms** for the baseline to **29.35–29.57 ms** for the quantized model, and **28.94 ms** for the extra-accelerated model of the last section. Each of these is the mean over one timed block after warm-up; the blocks run once each, in the order shown, baseline first, and no dispersion is reported.\n",
+    "## 4. Quantize\n",
     "\n",
-    "On accuracy, the trained baseline scores **81.17%** (3186/3925, Wilson 95% [79.92, 82.36]) and the quantized model **80.92%** (3176/3925, [79.66, 82.12]) — one run each, and the intervals overlap."
+    "`Quantizer(backend='pt2e')` captures the model with `torch.export` and rewrites it to compute in INT8.\n",
+    "Static quantization reads the activation ranges off calibration data, so it needs a loader."
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "b9e1aee0",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "wk023",
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'backend': 'pt2e', 'method': 'static', 'weight_bits': 8, 'act_bits': 8, 'qscheme': 'per_channel', 'symmetric': True, 'group_size': None, 'layer_bits': None, 'qdq_placement': 'per_op'}\n",
+      "W8A8 | exportable: True\n"
+     ]
+    }
+   ],
    "source": [
-    "<br>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9d3d25af",
-   "metadata": {},
-   "source": [
-    ":::{.callout-note}\n",
+    "BATCH = 2   # torch.export captures ONE batch size, and 1478 = 739 x 2\n",
     "\n",
-    "Please keep in mind that the techniques presented above are not magic 🧙‍♂️, so do not expect to see a 200% speedup and compression everytime. What you can achieve highly depend on the architecture that you are using (some are already speed/parameter efficient by design) or the task it is doing (some datasets are so easy that you can remove almost all your network without seeing a drop in performance)\n",
+    "model = learn.model.cpu().eval()\n",
+    "quantizer = Quantizer(backend='pt2e', method='static')\n",
+    "qmodel = quantizer.quantize(model, calibration_dl=dls.train.new(bs=BATCH),\n",
+    "                            max_calibration_samples=64)\n",
     "\n",
-    ":::"
+    "print(quantizer.spec.as_dict())\n",
+    "print(quant_spec(qmodel).label, \"| exportable:\", quant_spec(qmodel).exports)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "eeb27f61",
+   "id": "wk024",
    "metadata": {},
    "source": [
-    "<br>"
+    "`W8A8` is the resolved precision — 8-bit weights and activations, per-channel scales, a zero-point of\n",
+    "0 everywhere, as `qdq_stats` shows below — and it travels with the model. That graph still stores float\n",
+    "weights and simulates the quantization; the INT8 artifact is the next step's file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wk025",
+   "metadata": {},
+   "source": [
+    "## 5. Export\n",
+    "\n",
+    "`export_qdq` writes the quantize/dequantize pairs into the graph instead of folding them away.\n",
+    "`export_onnx` exports the float model, to have something to compare the file against."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "wk026",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[torch.onnx] Obtain model graph for `GraphModule([...]` with `torch.export.export(..., strict=False)`...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[torch.onnx] Obtain model graph for `GraphModule([...]` with `torch.export.export(..., strict=False)`... ✅\n",
+      "[torch.onnx] Run decomposition...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[torch.onnx] Run decomposition... ✅\n",
+      "[torch.onnx] Translate the graph into ONNX...\n",
+      "[torch.onnx] Translate the graph into ONNX... ✅\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pets_fp32.onnx 22.4 MB | pets_qdq.onnx 5.9 MB (3.8x smaller on disk)\n"
+     ]
+    }
+   ],
+   "source": [
+    "sample, _ = dls.valid.new(bs=BATCH).one_batch()\n",
+    "sample = sample.cpu()\n",
+    "\n",
+    "fp32_path = export_onnx(model, sample, tmp/\"pets_fp32.onnx\", dynamic_batch=False)\n",
+    "qdq_path = export_qdq(qmodel, sample, tmp/\"pets_qdq.onnx\")\n",
+    "\n",
+    "fp32_mb, qdq_mb = fp32_path.stat().st_size/1e6, qdq_path.stat().st_size/1e6\n",
+    "print(f\"{fp32_path.name} {fp32_mb:.1f} MB | {qdq_path.name} {qdq_mb:.1f} MB \"\n",
+    "      f\"({fp32_mb/qdq_mb:.1f}x smaller on disk)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "wk027",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'n_quantize': 36, 'n_dequantize': 58, 'n_per_channel': 22, 'n_nonzero_zero_point': 0, 'n_unquantized_conv_add': 0}\n",
+      "22 weight tensors (convolutions and Linear layers) in the model\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(qdq_stats(qdq_path).as_dict())\n",
+    "print(sum(1 for m in model.modules() if isinstance(m, (nn.Conv2d, nn.Linear))),\n",
+    "      \"weight tensors (convolutions and Linear layers) in the model\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wk028",
+   "metadata": {},
+   "source": [
+    "`qdq_stats` counts what the exporter actually wrote:\n",
+    "\n",
+    "- `n_quantize` / `n_dequantize` — the pairs a runtime reads to build its INT8 kernels.\n",
+    "- `n_per_channel` — one node per quantized weight tensor, which is the count printed above.\n",
+    "- `n_nonzero_zero_point` — 0, what a symmetric quantizer promised, read off the file.\n",
+    "- `n_unquantized_conv_add` — 0: every `Add` reads its inputs through a pair."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wk029",
+   "metadata": {},
+   "source": [
+    "`verify_qdq` reports how often the exported graph and the PyTorch model it came from predict the same\n",
+    "class — worth reading only if the reference predictions vary, so this checks first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "wk030",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "reference predictions per class: [182, 74]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "argmax agreement: 1.000 (256/256), Wilson 95% [98.52%, 100.00%]\n"
+     ]
+    }
+   ],
+   "source": [
+    "probe, _ = dls.valid.new(bs=256).one_batch()\n",
+    "probe = probe.cpu()\n",
+    "\n",
+    "with torch.no_grad():\n",
+    "    reference = torch.cat([qmodel(c).argmax(-1) for c in probe.split(BATCH)])\n",
+    "assert len(reference.unique()) > 1, \"the reference predicts a single class: agreement would be vacuous\"\n",
+    "print(\"reference predictions per class:\", torch.bincount(reference, minlength=2).tolist())\n",
+    "\n",
+    "agreement = verify_qdq(qmodel, qdq_path, probe, n_batches=len(probe)//BATCH)\n",
+    "k, n, z = round(agreement*len(probe)), len(probe), 1.96\n",
+    "p, d = k/n, 1 + z**2/n\n",
+    "c, h = p + z**2/(2*n), z*sqrt(p*(1-p)/n + z**2/(4*n**2))\n",
+    "print(f\"argmax agreement: {agreement:.3f} ({k}/{n}), Wilson 95% [{(c-h)/d:.2%}, {(c+h)/d:.2%}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wk031",
+   "metadata": {},
+   "source": [
+    "The reference predicts both classes, so the comparison is not vacuous, and the graph answers the same\n",
+    "class on every probe input. This is agreement with the quantized PyTorch model, not accuracy: it says\n",
+    "the file runs at the batch size it was captured with and computes what its source graph computes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wk032",
+   "metadata": {},
+   "source": [
+    "Agreement is not accuracy: the last cell scores the exported file over the whole validation set\n",
+    "through `ONNXModel` (onnxruntime behind a PyTorch-like call)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "wk033",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "exported INT8 graph: 91.95% (1359/1478), Wilson 95% [90.45%, 93.23%]\n"
+     ]
+    }
+   ],
+   "source": [
+    "onnx_model = ONNXModel(qdq_path)\n",
+    "\n",
+    "k = n = 0\n",
+    "for x, y in dls.valid.new(bs=BATCH):\n",
+    "    k += int((onnx_model(x.cpu()).argmax(-1) == y.cpu()).sum()); n += len(y)\n",
+    "z = 1.96; p, d = k/n, 1 + z**2/n\n",
+    "c, h = p + z**2/(2*n), z*sqrt(p*(1-p)/n + z**2/(4*n**2))\n",
+    "print(f\"exported INT8 graph: {k/n:.2%} ({k}/{n}), Wilson 95% [{(c-h)/d:.2%}, {(c+h)/d:.2%}]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "wk034",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "stage                   params   MMACs  conv zeros  state_dict   accuracy\n",
+      "baseline                11.44M     149        0.0%       45.9M     92.22%\n",
+      "sparsified              11.44M     149       50.0%       45.9M     93.84%\n",
+      "pruned                   5.59M      74       48.8%       22.4M          -\n",
+      "pruned + recovery        5.59M      74       50.0%       22.4M     92.02%\n",
+      "MMACs: multiply-accumulates for one 64x64 image | conv zeros: share of zeros in the convolution weights\n",
+      "\n",
+      "ONNX files: FP32 22.4 MB | QDQ INT8 5.9 MB, which scored 91.95% (1359/1478) on the validation set\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{'stage':<20}{'params':>10}{'MMACs':>8}{'conv zeros':>12}{'state_dict':>12}{'accuracy':>11}\")\n",
+    "for s in stages:\n",
+    "    acc = f\"{s['acc']:.2%}\" if s['acc'] is not None else \"-\"\n",
+    "    print(f\"{s['stage']:<20}{s['params']/1e6:>9.2f}M{s['macs']/1e6:>8.0f}\"\n",
+    "          f\"{s['zeros']:>12.1%}{s['mb']:>11.1f}M{acc:>11}\")\n",
+    "print(\"MMACs: multiply-accumulates for one 64x64 image | conv zeros: share of zeros in the \"\n",
+    "      \"convolution weights\")\n",
+    "print(f\"\\nONNX files: FP32 {fp32_mb:.1f} MB | QDQ INT8 {qdq_mb:.1f} MB, \"\n",
+    "      f\"which scored {k/n:.2%} ({k}/{n}) on the validation set\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wk035",
+   "metadata": {},
+   "source": [
+    "The four accuracies of this run are successive stages of one model, not the arms of an A/B — each row\n",
+    "carries a different training budget — and their Wilson intervals overlap, so this page ranks none of\n",
+    "them.\n",
+    "\n",
+    "**Scope.** ResNet-18 with ImageNet weights, PETS cat/dog labels, 64 px: three epochs of fine-tuning,\n",
+    "five with `SparsifyCallback`, one `Pruner` step, three recovery epochs, calibration on 64 training\n",
+    "images. Single run, no seed fixed; device and library versions printed at the top, the ONNX graphs\n",
+    "scored on CPU through onnxruntime. Accuracy is measured on the 1478 validation images with its Wilson\n",
+    "95% interval. This page measures no latency."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wk036",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "| Step | Tool | What it gives you |\n",
+    "|------|------|-------------------|\n",
+    "| Sparsify | `SparsifyCallback(sparsity, granularity, context, criteria, schedule)` | Weights zeroed during training, following the schedule |\n",
+    "| Prune | `Pruner(model, pruning_ratio, context, criteria)` | Filters removed, a structurally smaller model |\n",
+    "| Quantize | `Quantizer(backend='pt2e', method='static').quantize(model, calibration_dl)` | An INT8 graph, tagged with the precision that produced it |\n",
+    "| Export | `export_qdq(model, sample, path)` | An ONNX file whose Q/DQ pairs survived the export |\n",
+    "| Inspect | `qdq_stats(path)` | Node counts, per-channel count, zero-point audit |\n",
+    "| Verify | `verify_qdq(model, path, samples)` | Argmax agreement between the exported graph and PyTorch |\n",
+    "| Score | `ONNXModel(path)` | The exported file called like a PyTorch model |\n",
+    "| Cost | `tp.utils.count_ops_and_params` | MACs and parameters, at a given input size |\n",
+    "\n",
+    "`sparsity` and `pruning_ratio` are fractions in [0, 1]. `criteria` and `schedule` take the objects\n",
+    "exported by `fasterai.core.criteria` and `fasterai.core.schedule`.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## See Also\n",
+    "\n",
+    "- [Sparsify Callback](sparse/sparsify_callback.html) - The sparsification step on its own\n",
+    "- [Prune Callback](prune/prune_callback.html) - Pruning inside the training loop instead of between fits\n",
+    "- [Deployable INT8 Export](quantize/deployable_export.html) - The precision grammar and the QDQ export in detail\n",
+    "- [Knowledge Distillation](distill/distill_callback.html) - Training a student model from a teacher\n",
+    "- [BatchNorm Folding](misc/bn_folding.html) - Folding BatchNorm layers into their convolutions\n",
+    "- [FC Decomposition](misc/fc_decomposer.html) - Factorizing fully-connected layers\n",
+    "- [Sensitivity Analysis](analyze/sensitivity.html) - Per-layer compression targets"
    ]
   }
  ],


### PR DESCRIPTION
## Why

The walkthrough was a 137-cell VGG16 course on the pre-2024 API, importing a peer package and ending on a deprecated helper that crashed; the quickstart was 1,125 words of prose with no output; the overview listed a 2022 feature set with wrong signatures and six dead links.

## What changes

- `tutorials/walkthrough`: ResNet-18 on PETS, 18 markdown cells, one pipeline shown end to end: fine-tune → `SparsifyCallback(sparsity=0.5)` → `Pruner(0.3)` + recovery (with the sparsity held) → `Quantizer(backend='pt2e', method='static')` calibrated on 64 training images → `export_qdq` → `qdq_stats` read off the file (36 Q, 58 DQ, 22 per-channel, 0 non-zero zero-points) → a non-vacuous `verify_qdq` (reference class counts [182, 74] printed first, 256/256) → the exported graph scored on the whole validation set through `ONNXModel`. Parameters, MACs (torch-pruning's counter), zeros and file sizes printed per stage; accuracies printed as k/n with Wilson 95 % (1363, 1387, 1360, 1359 of 1478 — successive stages of one model, not arms of an A/B, and overlapping, so not ordered); FP32 ONNX 22.4 MB vs QDQ 5.9 MB. `concat_pool=False` because the fastai head has no ONNX function under the dynamo exporter; export batch 2 so all 1478 images pass through the static graph; the recovery fit re-applies the sparsity callback and the page says what that means (a fresh mask, ramped from 0). Torch, onnx and onnxruntime versions and the device are printed at the top. No latency, no peer-package import.
- `quickstart`: five executed cells: a `vision_learner`, one `fit_one_cycle` with `SparsifyCallback`, the per-layer report, the accuracy with k/n + Wilson (single run), a two-row Summary and where to go next.
- `overview`: the current surface (sparsify, prune, distill, regularize, quantize with Q/DQ export, export, analyze, misc) with signatures copied from the library, `vision_learner`, fractions, v0.3.3, links by stem; its two code cells stay CPU-cheap for CI.

Follow-up outside this PR: `README.md` now diverges from the overview (old signatures, `cnn_learner`, v0.1.6, dead tutorial links); generating it from the overview is the fix.

## Evidence

Executed with the in-tree fraction library; the percent warning is turned into an error in the hidden setup cells. 0 error outputs, 0 warnings stored, 30 relative links and 5 anchors resolving, `nbdev-clean` idempotent, `nbdev_test` default suite green (the overview runs in it). Numbers reviewed against the outputs before push.

https://claude.ai/code/session_0177tJZDQTTjQdycXV1EZtdJ
