### PR TITLE
ci: pin plum-dispatch below 2.10 until fastai imports on it

### DIFF
--- a/.github/constraints.txt
+++ b/.github/constraints.txt
@@ -1,0 +1,5 @@
+# CI-only pins (pip reads this through PIP_CONSTRAINT in workflows/test.yaml).
+# plum-dispatch 2.10.0 makes Function.__doc__ read-only, which breaks fastcore's add_docs while
+# fastai imports ('Function' object attribute '__doc__' is read-only); drop the line once a
+# fastcore/fastai release imports on plum-dispatch 2.10.
+plum-dispatch<2.10

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,4 +4,6 @@ on:  [workflow_dispatch, pull_request, push]
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      PIP_CONSTRAINT: ${{ github.workspace }}/.github/constraints.txt
     steps: [uses: fastai/workflows/nbdev3-ci@master]


### PR DESCRIPTION
## Why

Since 13:26 UTC today CI fails on every notebook that runs `from fastai.vision.all import *` (10 of 21 in the default suite):

```
File ".../fastai/data/transforms.py", line 366
File ".../fastcore/foundation.py", line 61
    f.__doc__ = v
AttributeError: 'Function' object attribute '__doc__' is read-only
```

The object is `plum._function.Function`: plum-dispatch 2.10.0 was released at 13:26:22 UTC, the minute the first red run started, and made that attribute read-only. plum is a dependency of fastai, and fastcore's `add_docs` writes `__doc__` on the dispatched `encodes` of every `Transform` at import time. Reproduced in a fresh venv, torch excluded as a cause:

```
plum 2.10.0  torch 2.13.0+cpu  -> AttributeError: 'Function' object attribute '__doc__' is read-only
plum 2.9.0   torch 2.13.0+cpu  -> fastai.vision.all import OK
plum 2.9.0   torch 2.14.0+cpu  -> fastai.vision.all import OK
```

## What changes

- `.github/constraints.txt`: `plum-dispatch<2.10`, with the reason and the removal condition in a comment.
- `.github/workflows/test.yaml`: `PIP_CONSTRAINT` points at that file, so the `pip install -e ".[dev]"` inside `fastai/workflows/nbdev3-ci` honours the pin.

The package's own dependencies are untouched: this is a CI environment pin, to be dropped once fastcore/fastai import on plum-dispatch 2.10.

Merge this first, then re-run CI on the open PRs (their earlier green runs predate the plum release; #65 is red only for this reason).

https://claude.ai/code/session_0177tJZDQTTjQdycXV1EZtdJ