### PR TITLE
docs(criteria): the demo helper takes a fraction, like the library

### DIFF
--- a/nbs/core/criteria.ipynb
+++ b/nbs/core/criteria.ipynb
@@ -75,7 +75,7 @@
     "#| include: false\n",
     "limit = np.linspace(-1, 1, 100)\n",
     "\n",
-    "def demo_model(criteria, sparsity=50):\n",
+    "def demo_model(criteria, sparsity=0.5):\n",
     "    model = models.resnet18(pretrained=True)\n",
     "    \n",
     "    #sp = Sparsifier(model, 'weight', 'local', criteria)\n",
@@ -87,7 +87,7 @@
     "    \n",
     "    \n",
     "    pruned_weights = criteria(model.conv1, 'weight')\n",
-    "    threshold = torch.quantile(pruned_weights.view(-1), sparsity/100)\n",
+    "    threshold = torch.quantile(pruned_weights.view(-1), sparsity)\n",
     "    mask = pruned_weights.ge(threshold).to(dtype=pruned_weights.dtype)\n",
     "    \n",
     "    \n",
@@ -787,7 +787,7 @@
     }
    ],
    "source": [
-    "demo_model(large_init_large_final, 80)"
+    "demo_model(large_init_large_final, 0.8)"
    ]
   },
   {
@@ -867,7 +867,7 @@
     }
    ],
    "source": [
-    "demo_model(magnitude_increase, 60)"
+    "demo_model(magnitude_increase, 0.6)"
    ]
   },
   {
@@ -1047,7 +1047,7 @@
     }
    ],
    "source": [
-    "demo_model(updating_movement, 50)"
+    "demo_model(updating_movement, 0.5)"
    ]
   },
   {
@@ -1328,7 +1328,7 @@
    "source": [
     "updating_movmag = Criteria(torch.abs, needs_update=True, output_fn=lambda x,y: torch.abs(torch.mul(x, torch.sub(x,y))))\n",
     "#updating_movmag = Criteria(noop, needs_update=True, output_fn=lambda x,y: torch.mul(x, torch.sub(x,y)))\n",
-    "demo_model(updating_movmag, 30)"
+    "demo_model(updating_movmag, 0.3)"
    ]
   },
   {
@@ -1351,7 +1351,7 @@
    "source": [
     "updating_movmag = Criteria(torch.abs, needs_update=True, output_fn=lambda x,y: torch.mul(x, torch.sub(x,y)))\n",
     "\n",
-    "demo_model(updating_movmag, 80)"
+    "demo_model(updating_movmag, 0.8)"
    ]
   },
   {
@@ -1419,7 +1419,7 @@
    ],
    "source": [
     "updating_movement = Criteria(noop, needs_update=True, output_fn= lambda x,y: torch.abs(torch.sub(-x,y)))\n",
-    "demo_model(updating_movement, 50)"
+    "demo_model(updating_movement, 0.5)"
    ]
   },
   {


### PR DESCRIPTION
## Summary

`nbs/core/criteria.ipynb`'s visible demo helper still took a percent (`demo_model(criteria, sparsity=50)` with `torch.quantile(..., sparsity/100)`) after the library moved to fractions in #58. The helper now takes `sparsity=0.5` and the six calls that passed a number pass the fraction (`0.8`, `0.6`, `0.5`, `0.3`, `0.8`, `0.5`). The computed thresholds are bit-identical (`80/100 == 0.8`), so the stored figures are kept as they were.

Nothing exported changes: `fasterai/core/criteria.py` is byte-identical, `_modidx.py` untouched. `nbdev_test` on the notebook: `Success.`; export + clean idempotent.

https://claude.ai/code/session_0177tJZDQTTjQdycXV1EZtdJ