### PR TITLE
docs(quantize): a short FakeQuantizer tutorial, calibrated on the normalized pipeline

### DIFF
--- a/nbs/tutorials/quantize/fake_quantizer.ipynb
+++ b/nbs/tutorials/quantize/fake_quantizer.ipynb
@@ -2,11 +2,11 @@
  "cells": [
   {
    "cell_type": "raw",
-   "id": "5a8e548ebfd6",
+   "id": "79428dd2d3e0",
    "metadata": {},
    "source": [
     "---\n",
-    "description: What 8-, 4- and 2-bit rounding costs three fine-tuned classifiers on Imagenette, measured through fastai\n",
+    "description: What rounding to 8, 4 and 2 bits costs a fine-tuned ResNet-18 on Imagenette, measured through fastai\n",
     "output-file: tutorial.fake_quantizer.html\n",
     "title: FakeQuantizer\n",
     "skip_showdoc: true\n",
@@ -16,20 +16,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "191450a8f2ad",
+   "id": "68bc17e15e0b",
    "metadata": {},
    "source": [
-    "`FakeQuantizer` rounds weights and activations onto a narrower grid and leaves the result in floating point. The model keeps its `float32` tensors and its ordinary modules; while it is rounded it also holds a floating-point copy of every weight it touched, so it takes more memory than it did before. When `act_bits` is set it additionally hooks every rounded module and rounds its output on each forward pass; with `act_bits=None` no hook is registered. The one thing it measures is what a width costs in **accuracy**.\n",
+    "`FakeQuantizer` rounds weights and activations onto a narrower grid and leaves the result in `float32`, so the model is no smaller and no faster: what it measures is what a width costs in accuracy.\n",
     "\n",
-    "This page rounds three fine-tuned classifiers — `vgg16_bn`, `resnet18` and `efficientnet_b0` — to the same grid of widths and reports what each one costs on Imagenette.\n",
-    "\n",
-    "**Scope, before any number.** Each architecture is fine-tuned once, each configuration is validated once, and every static row observes one fixed calibration set. Three architectures trained once each is an observation about these three fine-tuned models, not a controlled comparison between architectures: nothing here separates what the architecture does from what this particular fine-tune did. The page reports accuracy and prediction changes, and measures no latency."
+    "Everything below is one fine-tune of one architecture and one validation pass per configuration — single run, no repetition."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d8efaf7ae47",
+   "id": "7f78220fab19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "055bc168d160",
+   "id": "93e5180db1cd",
    "metadata": {},
    "source": [
     "## Setup"
@@ -49,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e6fa90eb79f6",
+   "id": "02a12d7633ea",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,93 +61,85 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8e8bd601480",
+   "id": "125ba3b30c3c",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "torch 2.9.1+cu128\n",
-      "device cuda (NVIDIA GeForce RTX 5090)\n"
+      "torch 2.9.1+cu128 on cuda, matmul precision highest\n"
      ]
     }
    ],
    "source": [
     "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
-    "print(f'torch {torch.__version__}')\n",
-    "print(f'device {device} ({torch.cuda.get_device_name(0) if device.type == \"cuda\" else \"cpu\"})')"
+    "print(f'torch {torch.__version__} on {device}, matmul precision {torch.get_float32_matmul_precision()}')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "32a71b6ebaa1",
+   "id": "3647139d0679",
    "metadata": {},
    "source": [
-    "Imagenette at 160 pixels, one `fine_tune(1)` per architecture — one frozen epoch and one unfrozen one, enough to give each model a floating-point accuracy to be read against.\n",
-    "\n",
-    "Calibration gets its own fixed loader rather than a handful of shuffled training batches. `dls.test_dl` applies validation-style preprocessing, so the five batches are the same on every call and every static row below observes exactly the same activations. [What the calibration set decides](#what-the-calibration-set-decides) measures how much that choice is worth."
+    "Imagenette at 160 pixels, one `resnet18`, one `fine_tune(1)`, `set_seed` before the loader and before the learner. `Normalize` is named on the loader, so the calibration set built with `dls.test_dl` sees the validation loader's batch pipeline — the two printed pipelines are that guard."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "025158ebf921",
+   "id": "5bcbd0467b88",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3925 validation images, 9469 training images\n",
-      "calibration set: 5 batches, 10 classes\n"
+      "9469 training images, 3925 validation images, 10 classes\n",
+      "calibration set  5 batches\n",
+      "valid pipeline   ['IntToFloatTensor', 'Normalize']\n",
+      "calib pipeline   ['IntToFloatTensor', 'Normalize']\n"
      ]
     }
    ],
    "source": [
+    "set_seed(42, reproducible=True)\n",
     "path = untar_data(URLs.IMAGENETTE_160)\n",
-    "dls = ImageDataLoaders.from_folder(path, valid='val', item_tfms=Resize(160), bs=32)\n",
+    "dls = ImageDataLoaders.from_folder(path, valid='val', item_tfms=Resize(160), bs=32,\n",
+    "                                   batch_tfms=Normalize.from_stats(*imagenet_stats))\n",
     "N = len(dls.valid_ds)\n",
     "\n",
-    "# one fixed calibration set, so every static row on this page observes the same batches\n",
     "files = sorted(get_image_files(path/'train'))\n",
     "calib_dl = dls.test_dl(files[::len(files)//160][:160], bs=32)\n",
     "\n",
-    "print(f'{N} validation images, {len(dls.train_ds)} training images')\n",
-    "print(f'calibration set: {len(calib_dl)} batches, {len({f.parent.name for f in files[::len(files)//160][:160]})} classes')"
+    "print(f'{len(dls.train_ds)} training images, {N} validation images, {dls.c} classes')\n",
+    "print(f'calibration set  {len(calib_dl)} batches')\n",
+    "print(f'valid pipeline   {[type(t).__name__ for t in dls.valid.after_batch]}')\n",
+    "print(f'calib pipeline   {[type(t).__name__ for t in calib_dl.after_batch]}')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8caba2692367",
+   "id": "f92ae886dbe5",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "vgg16_bn          96.92% (3804/3925)   Wilson 95% [96.33, 97.41]\n",
-      "resnet18          95.95% (3766/3925)   Wilson 95% [95.29, 96.52]\n",
-      "efficientnet_b0   95.44% (3746/3925)   Wilson 95% [94.74, 96.05]\n"
+      "floating point   96.28% (3779/3925)   Wilson 95% [95.64, 96.83]\n"
      ]
     }
    ],
    "source": [
-    "def wilson(k, n, z=1.96):\n",
+    "def wilson(k, n):\n",
     "    \"Wilson 95% interval for k of n, as percentages\"\n",
+    "    z = 1.96\n",
     "    p, d = k / n, 1 + z * z / n\n",
     "    c = (p + z * z / (2 * n)) / d\n",
     "    h = z / d * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n))\n",
     "    return 100 * max(0., c - h), 100 * min(1., c + h)\n",
-    "\n",
-    "def finetune(arch):\n",
-    "    \"A fastai `vision_learner` fine-tuned for one cycle on Imagenette\"\n",
-    "    set_seed(42, reproducible=True)\n",
-    "    learn = vision_learner(dls, arch, metrics=accuracy)\n",
-    "    with learn.no_bar(), learn.no_logging():\n",
-    "        learn.fine_tune(1)\n",
-    "    return learn\n",
     "\n",
     "def score(learn):\n",
     "    \"Validation accuracy of `learn`, as a percentage and as k/n\"\n",
@@ -163,691 +153,288 @@
     "        preds, _ = learn.get_preds(dl=dls.valid)\n",
     "    return preds.argmax(1)\n",
     "\n",
-    "learners = {'vgg16_bn': finetune(vgg16_bn),\n",
-    "            'resnet18': finetune(resnet18),\n",
-    "            'efficientnet_b0': finetune(efficientnet_b0)}\n",
-    "float_pred = {name: predictions(learn) for name, learn in learners.items()}\n",
+    "set_seed(42, reproducible=True)\n",
+    "learn = vision_learner(dls, resnet18, metrics=accuracy)\n",
+    "with learn.no_bar(), learn.no_logging():\n",
+    "    learn.fine_tune(1)\n",
     "\n",
-    "for name, learn in learners.items():\n",
-    "    pct, k, n = score(learn)\n",
-    "    lo, hi = wilson(k, n)\n",
-    "    print(f'{name:<18}{pct:.2f}% ({k}/{n})   Wilson 95% [{lo:.2f}, {hi:.2f}]')"
+    "float_pred = predictions(learn)\n",
+    "pct, k, n = score(learn)\n",
+    "lo, hi = wilson(k, n)\n",
+    "print(f'floating point   {pct:.2f}% ({k}/{n})   Wilson 95% [{lo:.2f}, {hi:.2f}]')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2fb7fba87a80",
+   "id": "0215cd0373ec",
    "metadata": {},
    "source": [
-    "Those three are the references every row below is read against. The Wilson 95% intervals span about a point each, which is the yardstick for reading the small differences further down: at this n, a handful of images is well inside the interval."
+    "That is the reference every row below is read against: 96.28% (3779/3925), with a Wilson 95% interval of [95.64, 96.83]."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8dfd408ef001",
+   "id": "46f4f88cc344",
    "metadata": {},
    "source": [
-    "## What rounding does not do\n",
+    "## Round the weights\n",
     "\n",
-    "The model does not get smaller. `quantize_model()` writes rounded values back into the same `float32` tensors and registers a buffer holding the original of every weight it rounds, so the model grows while it is rounded and shrinks back on `remove()`."
+    "`quantize_model()` writes the rounded values into the same `float32` tensors and keeps a copy of the originals; `print_precision()` names the width every layer carries, and `remove()` puts the floating-point weights back."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d487c31e2a02",
+   "id": "ba4f41d5bc0b",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "dtype while rounded  torch.float32\n",
-      "bytes while rounded  93,672,288\n",
-      "spec while rounded   W8A8\n",
-      "bytes after remove() 46,886,832\n",
-      "spec after remove()  None\n",
-      "weights restored     True\n"
-     ]
-    }
-   ],
-   "source": [
-    "def nbytes(m):\n",
-    "    \"Bytes held by every parameter and buffer of `m`\"\n",
-    "    return (sum(p.numel() * p.element_size() for p in m.parameters())\n",
-    "            + sum(b.numel() * b.element_size() for b in m.buffers()))\n",
-    "\n",
-    "model = learners['resnet18'].model\n",
-    "before = {k: v.detach().clone() for k, v in model.state_dict().items()}\n",
-    "\n",
-    "fq = FakeQuantizer(model, weight_bits=8, act_bits=8, qscheme='per_channel')\n",
-    "fq.calibrate(calib_dl, n_batches=5)\n",
-    "fq.quantize_model()\n",
-    "\n",
-    "print(f'dtype while rounded  {next(model.parameters()).dtype}')\n",
-    "print(f'bytes while rounded  {nbytes(model):,}')\n",
-    "print(f'spec while rounded   {fake_quant_spec(model).label}')\n",
-    "\n",
-    "fq.remove()\n",
-    "print(f'bytes after remove() {nbytes(model):,}')\n",
-    "print(f'spec after remove()  {fake_quant_spec(model)}')\n",
-    "print(f'weights restored     {all(torch.equal(before[k], v) for k, v in model.state_dict().items())}')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "855c5c677c86",
-   "metadata": {},
-   "source": [
-    "Rounded, this ResNet-18 holds 93,672,288 bytes of parameters and buffers against 46,886,832 before. `remove()` puts the original weights back byte for byte and drops the spec.\n",
-    "\n",
-    "Four more things stay outside the rounding:\n",
-    "\n",
-    "- **Biases stay in floating point.** An integer kernel would carry them at int32; this class does not model that.\n",
-    "- **BatchNorm is not folded** into the convolution it follows. Folding changes the weights that get rounded, so a folded model and an unfolded one give different answers at the same width — [`BN_Folder`](../../misc/bn_folding.html) does the folding.\n",
-    "- **`nn.Embedding` and `nn.ConvTranspose2d` are outside the default `layer_type`**, which is `(nn.Conv2d, nn.Linear)`. A model holding them keeps those tensors byte-identical while the report still names a width.\n",
-    "- **A rounded model is not a QAT model.** Its weights are baked: they sit on the grid now, and training would walk them straight off it. Quantization-aware training is not in this version.\n",
-    "\n",
-    "`print_precision()` names the width every layer carries. Here `layer_bits` holds the first convolution in floating point:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d1b559c70cfc",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "W8 weights       96.25% (3778/3925)   8 of 3925 predictions changed\n",
+      "spec             W8AF\n",
       "\n",
       "Simulated Precision Report:\n",
       "--------------------------------------------------------------------------------\n",
       "Layer                            Type           Weight     Act        Weight axis \n",
       "--------------------------------------------------------------------------------\n",
-      "0.0                              Conv2d         float      8 bits     -           \n",
-      "0.4.0.conv1                      Conv2d         8 bits     8 bits     per_channel \n",
-      "0.4.0.conv2                      Conv2d         8 bits     8 bits     per_channel \n",
-      "0.4.1.conv1                      Conv2d         8 bits     8 bits     per_channel \n",
-      "0.4.1.conv2                      Conv2d         8 bits     8 bits     per_channel \n",
-      "0.5.0.conv1                      Conv2d         8 bits     8 bits     per_channel \n",
-      "0.5.0.conv2                      Conv2d         8 bits     8 bits     per_channel \n",
-      "0.5.0.downsample.0               Conv2d         8 bits     8 bits     per_channel \n",
-      "0.5.1.conv1                      Conv2d         8 bits     8 bits     per_channel \n",
-      "0.5.1.conv2                      Conv2d         8 bits     8 bits     per_channel \n",
-      "0.6.0.conv1                      Conv2d         8 bits     8 bits     per_channel \n",
-      "0.6.0.conv2                      Conv2d         8 bits     8 bits     per_channel \n",
-      "0.6.0.downsample.0               Conv2d         8 bits     8 bits     per_channel \n",
-      "0.6.1.conv1                      Conv2d         8 bits     8 bits     per_channel \n",
-      "0.6.1.conv2                      Conv2d         8 bits     8 bits     per_channel \n",
-      "0.7.0.conv1                      Conv2d         8 bits     8 bits     per_channel \n",
-      "0.7.0.conv2                      Conv2d         8 bits     8 bits     per_channel \n",
-      "0.7.0.downsample.0               Conv2d         8 bits     8 bits     per_channel \n",
-      "0.7.1.conv1                      Conv2d         8 bits     8 bits     per_channel \n",
-      "0.7.1.conv2                      Conv2d         8 bits     8 bits     per_channel \n",
-      "1.4                              Linear         8 bits     8 bits     per_channel \n",
-      "1.8                              Linear         8 bits     8 bits     per_channel \n",
+      "0.0                              Conv2d         8 bits     float      per_channel \n",
+      "0.4.0.conv1                      Conv2d         8 bits     float      per_channel \n",
+      "0.4.0.conv2                      Conv2d         8 bits     float      per_channel \n",
+      "0.4.1.conv1                      Conv2d         8 bits     float      per_channel \n",
+      "0.4.1.conv2                      Conv2d         8 bits     float      per_channel \n",
+      "0.5.0.conv1                      Conv2d         8 bits     float      per_channel \n",
+      "0.5.0.conv2                      Conv2d         8 bits     float      per_channel \n",
+      "0.5.0.downsample.0               Conv2d         8 bits     float      per_channel \n",
+      "0.5.1.conv1                      Conv2d         8 bits     float      per_channel \n",
+      "0.5.1.conv2                      Conv2d         8 bits     float      per_channel \n",
+      "0.6.0.conv1                      Conv2d         8 bits     float      per_channel \n",
+      "0.6.0.conv2                      Conv2d         8 bits     float      per_channel \n",
+      "0.6.0.downsample.0               Conv2d         8 bits     float      per_channel \n",
+      "0.6.1.conv1                      Conv2d         8 bits     float      per_channel \n",
+      "0.6.1.conv2                      Conv2d         8 bits     float      per_channel \n",
+      "0.7.0.conv1                      Conv2d         8 bits     float      per_channel \n",
+      "0.7.0.conv2                      Conv2d         8 bits     float      per_channel \n",
+      "0.7.0.downsample.0               Conv2d         8 bits     float      per_channel \n",
+      "0.7.1.conv1                      Conv2d         8 bits     float      per_channel \n",
+      "0.7.1.conv2                      Conv2d         8 bits     float      per_channel \n",
+      "1.4                              Linear         8 bits     float      per_channel \n",
+      "1.8                              Linear         8 bits     float      per_channel \n",
       "--------------------------------------------------------------------------------\n",
-      "Overall                          W8A8          \n",
-      "Rounded in floating point: every tensor is still stored at its original width, and the model holds a floating-point copy of every weight it rounds until remove().\n"
+      "Overall                          W8AF          \n",
+      "Rounded in floating point: every tensor is still stored at its original width, and the model holds a floating-point copy of every weight it rounds until remove().\n",
+      "\n",
+      "weights restored byte for byte  True\n",
+      "spec after remove()             None\n"
      ]
     }
    ],
    "source": [
-    "fq = FakeQuantizer(model, weight_bits=8, act_bits=8, qscheme='per_channel',\n",
-    "                   layer_bits={'0.0': None})\n",
-    "fq.calibrate(calib_dl, n_batches=5)\n",
+    "before = {key: t.detach().clone() for key, t in learn.model.state_dict().items()}\n",
+    "\n",
+    "fq = FakeQuantizer(learn.model, weight_bits=8)\n",
     "fq.quantize_model()\n",
+    "\n",
+    "pct, k, n = score(learn)\n",
+    "flips = int((predictions(learn) != float_pred).sum())\n",
+    "print(f'W8 weights       {pct:.2f}% ({k}/{n})   {flips} of {n} predictions changed')\n",
+    "print(f'spec             {fake_quant_spec(learn.model).label}')\n",
+    "\n",
     "fq.print_precision()\n",
-    "fq.remove()"
+    "\n",
+    "fq.remove()\n",
+    "print(f'\\nweights restored byte for byte  '\n",
+    "      f'{all(torch.equal(before[key], t) for key, t in learn.model.state_dict().items())}')\n",
+    "print(f'spec after remove()             {fake_quant_spec(learn.model)}')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2f86e936df65",
+   "id": "0bd54e03c932",
    "metadata": {},
    "source": [
-    "## The widths, three models\n",
+    "Eight-bit weights give 96.25% (3778/3925) against 96.28% (3779/3925) in floating point, one image apart and well inside that interval, with 8 of 3925 predictions changed. After `remove()` the state dict is byte for byte what it was, and `fake_quant_spec` reads `None` again."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3adb8eb8454a",
+   "metadata": {},
+   "source": [
+    "## Three widths\n",
     "\n",
-    "Each configuration is built on the fine-tuned model, validated, and removed before the next one starts. Alongside the accuracy, each row counts the validation images whose predicted class differs from the floating-point model's — a row that changed nothing would show zero, so the count is what separates a real effect from a no-op."
+    "`measure` rounds the model to one configuration, scores it, counts the validation images whose predicted class differs from the floating-point model's, and restores the weights."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "00c10dab1f15",
+   "id": "ba29388b654d",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "                                vgg16_bn           resnet18           efficientnet_b0    \n",
-      "floating point                  96.92% 3804/3925   95.95% 3766/3925   95.44% 3746/3925   \n",
-      "W8A8 static, per_channel        96.97% 3806/3925   95.34% 3742/3925   64.36% 2526/3925   \n",
-      "W8 weights-only, per_channel    97.04% 3809/3925   95.90% 3764/3925   95.39% 3744/3925   \n",
-      "W8 weights-only, per_tensor     96.97% 3806/3925   96.00% 3768/3925   95.52% 3749/3925   \n",
-      "W4A8 static, per_channel        94.09% 3693/3925   88.92% 3490/3925   30.96% 1215/3925   \n",
-      "W4 weights-only, per_channel    94.39% 3705/3925   89.96% 3531/3925   45.35% 1780/3925   \n",
-      "W4 weights-only, per_tensor     22.78% 894/3925    26.50% 1040/3925   10.78% 423/3925    \n",
-      "W2A8 static, per_channel        10.39% 408/3925    10.06% 395/3925    11.54% 453/3925    \n",
-      "W2 weights-only, per_channel    10.42% 409/3925    10.06% 395/3925    10.65% 418/3925    \n",
-      "\n",
-      "images whose predicted class differs from the floating-point model, of 3925\n",
-      "                                vgg16_bn           resnet18           efficientnet_b0    \n",
-      "floating point                  0                  0                  0                  \n",
-      "W8A8 static, per_channel        29                 52                 1386               \n",
-      "W8 weights-only, per_channel    6                  9                  50                 \n",
-      "W8 weights-only, per_tensor     16                 16                 67                 \n",
-      "W4A8 static, per_channel        182                379                2727               \n",
-      "W4 weights-only, per_channel    171                331                2140               \n",
-      "W4 weights-only, per_tensor     3027               2876               3509               \n",
-      "W2A8 static, per_channel        3522               3536               3474               \n",
-      "W2 weights-only, per_channel    3521               3536               3498               \n"
+      "W8 per_channel   96.25% (3778/3925)   8 flips\n",
+      "W4 per_channel   90.14% (3538/3925)   332 flips\n",
+      "W2 per_channel   10.42% (409/3925)   3524 flips\n"
      ]
     }
    ],
    "source": [
-    "def measure(learn, ref=None, calib=None, **kw):\n",
-    "    \"Round `learn.model` to one configuration, validate it, and restore the floating-point weights\"\n",
+    "def measure(**kw):\n",
+    "    \"Round the model to one configuration, score it, and restore the floating-point weights\"\n",
     "    fq = FakeQuantizer(learn.model, **kw)\n",
     "    try:\n",
-    "        if fq.observer == 'static' and fq.act_bits is not None:\n",
-    "            fq.calibrate(calib if calib is not None else calib_dl, n_batches=5)\n",
+    "        if fq.act_bits is not None: fq.calibrate(calib_dl, n_batches=5)\n",
     "        fq.quantize_model()\n",
     "        pct, k, n = score(learn)\n",
-    "        flips = None if ref is None else int((predictions(learn) != ref).sum())\n",
-    "        return pct, k, n, flips\n",
+    "        return pct, k, n, int((predictions(learn) != float_pred).sum())\n",
     "    finally:\n",
     "        fq.remove()\n",
     "\n",
-    "CONFIGS = {\n",
-    "    'W8A8 static, per_channel':     dict(weight_bits=8, act_bits=8,    qscheme='per_channel'),\n",
-    "    'W8 weights-only, per_channel': dict(weight_bits=8, act_bits=None, qscheme='per_channel'),\n",
-    "    'W8 weights-only, per_tensor':  dict(weight_bits=8, act_bits=None, qscheme='per_tensor'),\n",
-    "    'W4A8 static, per_channel':     dict(weight_bits=4, act_bits=8,    qscheme='per_channel'),\n",
-    "    'W4 weights-only, per_channel': dict(weight_bits=4, act_bits=None, qscheme='per_channel'),\n",
-    "    'W4 weights-only, per_tensor':  dict(weight_bits=4, act_bits=None, qscheme='per_tensor'),\n",
-    "    'W2A8 static, per_channel':     dict(weight_bits=2, act_bits=8,    qscheme='per_channel'),\n",
-    "    'W2 weights-only, per_channel': dict(weight_bits=2, act_bits=None, qscheme='per_channel'),\n",
-    "}\n",
-    "\n",
-    "rows = {'floating point': {n: (*score(l), 0) for n, l in learners.items()}}\n",
-    "for label, kw in CONFIGS.items():\n",
-    "    rows[label] = {n: measure(l, ref=float_pred[n], **kw) for n, l in learners.items()}\n",
-    "\n",
-    "print(f'{\"\":<32}' + ''.join(f'{name:<19}' for name in learners))\n",
-    "for label, per_arch in rows.items():\n",
-    "    cells = ''.join(f'{pct:.2f}% {k}/{n}'.ljust(19) for pct, k, n, _ in\n",
-    "                    (per_arch[name] for name in learners))\n",
-    "    print(f'{label:<32}{cells}')\n",
-    "\n",
-    "print(f'\\nimages whose predicted class differs from the floating-point model, of {N}')\n",
-    "print(f'{\"\":<32}' + ''.join(f'{name:<19}' for name in learners))\n",
-    "for label, per_arch in rows.items():\n",
-    "    print(f'{label:<32}' + ''.join(f'{per_arch[name][3]}'.ljust(19) for name in learners))"
+    "for bits in (8, 4, 2):\n",
+    "    pct, k, n, flips = measure(weight_bits=bits, qscheme='per_channel')\n",
+    "    print(f'W{bits} per_channel   {pct:.2f}% ({k}/{n})   {flips} flips')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8a66fa547992",
+   "id": "b293907f6910",
    "metadata": {},
    "source": [
-    "**At 8 bits on the weights alone**, every row lands within a handful of images of its reference, in both directions: `vgg16_bn` goes from 3804/3925 to 3809/3925 correct, `resnet18` from 3766/3925 to 3764/3925, `efficientnet_b0` from 3746/3925 to 3744/3925. All six differences sit inside the Wilson intervals printed above. The flip counts show this is not a no-op — 6, 9 and 50 images changed class — so what the accuracy column shows is many small changes very nearly cancelling.\n",
-    "\n",
-    "**Adding 8-bit activations splits the three.** `vgg16_bn` and `resnet18` stay put at 96.97% (3806/3925) and 95.34% (3742/3925), while `efficientnet_b0` drops to 64.36% (2526/3925) with 1386 images changing class against 50 for its weights-only row. Its weights survive 8 bits; its activations do not. That contrast is a one-variable comparison — the same model, the same calibration set, `act_bits` alone moved — and it is by far the largest effect on this page.\n",
-    "\n",
-    "**At 4 bits** the order across the three models is the one the 8-bit rows already had, and the gaps widen: 94.39% (3705/3925), 89.96% (3531/3925) and 45.35% (1780/3925) per channel. `resnet18` gives up more than `vgg16_bn` here, and with one fine-tune each that is a fact about these two trained models rather than a ranking of the architectures.\n",
-    "\n",
-    "**At 2 bits** none of the three separates the classes any more, and roughly nine validation images in ten have changed class."
+    "Weights only, one scale per output row: 8 bits stays at 96.25% (3778/3925), 4 bits gives 90.14% (3538/3925) with 332 flips, and 2 bits gives 10.42% (409/3925) with 3524 of 3925 predictions changed, which is where a 10-class guess lands."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9199427af0ee",
+   "id": "724220641bbc",
    "metadata": {},
    "source": [
-    "### Two guards\n",
+    "## The activations too\n",
     "\n",
-    "Seven apply-and-remove cycles have run against each model by now. Re-scoring the untouched models has to give the opening numbers back:"
+    "`act_bits` hooks every rounded module and rounds its output as well. Under `observer='static'` those scales are frozen by `calibrate`, which observes the fixed calibration set before `quantize_model()` runs."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05d419961c40",
+   "id": "c423a0470b3e",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "vgg16_bn          96.92% (3804/3925)\n",
-      "resnet18          95.95% (3766/3925)\n",
-      "efficientnet_b0   95.44% (3746/3925)\n"
+      "W8A8 static, per_channel   96.13% (3773/3925)   30 flips\n",
+      "W4A8 static, per_channel   90.01% (3533/3925)   335 flips\n"
      ]
     }
    ],
    "source": [
-    "for name, learn in learners.items():\n",
-    "    pct, k, n = score(learn)\n",
-    "    print(f'{name:<18}{pct:.2f}% ({k}/{n})')"
+    "for bits in (8, 4):\n",
+    "    pct, k, n, flips = measure(weight_bits=bits, act_bits=8, qscheme='per_channel')\n",
+    "    print(f'W{bits}A8 static, per_channel   {pct:.2f}% ({k}/{n})   {flips} flips')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "01ee23dceddc",
+   "id": "14f175cddd39",
    "metadata": {},
    "source": [
-    "It does. Nothing leaked between configurations.\n",
-    "\n",
-    "The second guard checks the other direction — that the rounding actually landed on a grid instead of being a near-no-op. Under `per_channel` each output row carries its own scale, so each row can take at most `2**bits` distinct values:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e67840b7dbdc",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "vgg16_bn          float    4608   W8  228 <= 256   W4   15 <= 16   W2    3 <= 4\n",
-      "resnet18          float    4608   W8  224 <= 256   W4   15 <= 16   W2    3 <= 4\n",
-      "efficientnet_b0   float    2560   W8  224 <= 256   W4   15 <= 16   W2    3 <= 4\n"
-     ]
-    }
-   ],
-   "source": [
-    "def row_values(learn, qscheme, **kw):\n",
-    "    \"Largest number of distinct values any single scaled row of a weight takes\"\n",
-    "    fq = FakeQuantizer(learn.model, qscheme=qscheme, **kw) if kw else None\n",
-    "    try:\n",
-    "        if fq is not None: fq.quantize_model()\n",
-    "        worst = 0\n",
-    "        for m in learn.model.modules():\n",
-    "            if not isinstance(m, (nn.Conv2d, nn.Linear)): continue\n",
-    "            w = m.weight.detach()\n",
-    "            rows_ = w.flatten(1) if qscheme == 'per_channel' else w.reshape(1, -1)\n",
-    "            worst = max(worst, max(int(r.unique().numel()) for r in rows_))\n",
-    "        return worst\n",
-    "    finally:\n",
-    "        if fq is not None: fq.remove()\n",
-    "\n",
-    "for name, learn in learners.items():\n",
-    "    out = [f'float {row_values(learn, \"per_channel\"):7d}']\n",
-    "    for bits in (8, 4, 2):\n",
-    "        got = row_values(learn, 'per_channel', weight_bits=bits, act_bits=None)\n",
-    "        out.append(f'W{bits} {got:4d} <= {2 ** bits}')\n",
-    "    print(f'{name:<18}' + '   '.join(out))"
+    "Adding 8-bit activations gives 96.13% (3773/3925) under 8-bit weights and 90.01% (3533/3925) under 4-bit ones, against 96.25% (3778/3925) and 90.14% (3538/3925) for the same weight widths alone. Both rows land within a handful of images of their weights-only row."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3a405d4c7246",
-   "metadata": {},
-   "source": [
-    "In floating point the widest row of these models takes 4608, 4608 and 2560 distinct values; rounded, no row exceeds its budget of 256, 16 and 4."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "23708ef68165",
+   "id": "67079a4a9383",
    "metadata": {},
    "source": [
     "## Where the scale comes from\n",
     "\n",
-    "`qscheme` picks the axis the scale is fitted on. `per_tensor` fits one scale to the whole weight tensor; `per_channel` fits one per output row.\n",
-    "\n",
-    "**At 8 bits the axis barely matters, and it does not order consistently.** `per_tensor` finishes above `per_channel` on `resnet18`, 96.00% (3768/3925) against 95.90% (3764/3925), and on `efficientnet_b0`, 95.52% (3749/3925) against 95.39% (3744/3925) — and below it on `vgg16_bn`, 96.97% (3806/3925) against 97.04% (3809/3925). Every one of those differences is a few images inside a Wilson interval about a point wide, so on all three of these models the 8-bit rows do not establish that either axis dominates.\n",
-    "\n",
-    "**At 4 bits the axis decides the outcome.** `per_tensor` falls to 22.78% (894/3925), 26.50% (1040/3925) and 10.78% (423/3925), against 94.39% (3705/3925), 89.96% (3531/3925) and 45.35% (1780/3925) per channel. One scale has to cover the loudest row of the tensor, and at four bits the quiet rows round away entirely:"
+    "`qscheme` picks the axis the scale is fitted on: `per_tensor` fits one scale to the whole weight tensor, `per_channel` one per output row."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98a85becc0ce",
+   "id": "f9fd68e432b0",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "vgg16_bn          float    0   faint (<1e-6)   11   W4 per_tensor    81   W4 per_channel    6\n",
-      "resnet18          float    0   faint (<1e-6)    6   W4 per_tensor    15   W4 per_channel    4\n",
-      "efficientnet_b0   float    0   faint (<1e-6)    0   W4 per_tensor   413   W4 per_channel    0\n"
+      "W4 per_channel    90.14% (3538/3925)   332 flips\n",
+      "W4 per_tensor     24.23% (951/3925)   2976 flips\n",
+      "\n",
+      "widest output channel holds 15 distinct values, of 2**4 = 16\n"
      ]
     }
    ],
    "source": [
-    "def dead_filters(learn, **kw):\n",
-    "    \"Output filters whose weights are all zero\"\n",
-    "    fq = FakeQuantizer(learn.model, **kw) if kw else None\n",
-    "    try:\n",
-    "        if fq is not None: fq.quantize_model()\n",
-    "        return sum(int((m.weight.flatten(1).abs().sum(1) == 0).sum())\n",
-    "                   for m in learn.model.modules() if isinstance(m, (nn.Conv2d, nn.Linear)))\n",
-    "    finally:\n",
-    "        if fq is not None: fq.remove()\n",
+    "for qscheme in ('per_channel', 'per_tensor'):\n",
+    "    pct, k, n, flips = measure(weight_bits=4, qscheme=qscheme)\n",
+    "    print(f'W4 {qscheme:<12}   {pct:.2f}% ({k}/{n})   {flips} flips')\n",
     "\n",
-    "def faint_filters(learn):\n",
-    "    \"Output filters whose largest floating-point weight is below 1e-6\"\n",
-    "    return sum(int((m.weight.flatten(1).abs().amax(1) < 1e-6).sum())\n",
-    "               for m in learn.model.modules() if isinstance(m, (nn.Conv2d, nn.Linear)))\n",
-    "\n",
-    "for name, learn in learners.items():\n",
-    "    base = dead_filters(learn)\n",
-    "    pt = dead_filters(learn, weight_bits=4, act_bits=None, qscheme='per_tensor')\n",
-    "    pc = dead_filters(learn, weight_bits=4, act_bits=None, qscheme='per_channel')\n",
-    "    print(f'{name:<18}float {base:4d}   faint (<1e-6) {faint_filters(learn):4d}   '\n",
-    "          f'W4 per_tensor {pt:5d}   W4 per_channel {pc:4d}')"
+    "fq = FakeQuantizer(learn.model, weight_bits=4, qscheme='per_channel')\n",
+    "fq.quantize_model()\n",
+    "widest = max(int(row.unique().numel()) for m in learn.model.modules()\n",
+    "             if isinstance(m, (nn.Conv2d, nn.Linear)) for row in m.weight.detach().flatten(1))\n",
+    "fq.remove()\n",
+    "print(f'\\nwidest output channel holds {widest} distinct values, of 2**4 = {2 ** 4}')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1ab62d8c2e74",
+   "id": "b7cb30c0cad9",
    "metadata": {},
    "source": [
-    "No filter is empty in floating point on any of the three. `per_channel` empties 6 and 4 on the two models that already hold 11 and 6 rows whose largest weight is below 1e-6, and empties none on `efficientnet_b0`, which has no such row — those are rows the scale floor collapses, not rows the 4-bit grid destroyed. `per_tensor` empties 81, 15 and 413, and the accuracy rows above are what that costs."
+    "At 4 bits the axis decides the outcome — 90.14% (3538/3925) per channel against 24.23% (951/3925) per tensor, with 2976 of 3925 predictions changed. One scale has to cover the loudest row of the tensor, and the quiet rows round away. The widest output channel holds 15 of the 16 values a 4-bit grid carries: the symmetric grid puts a row's extreme on the highest integer and leaves the lowest unused."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e8597c013913",
-   "metadata": {},
-   "source": [
-    "## Groups, and a refusal\n",
-    "\n",
-    "`qscheme='per_group'` cuts each row into fixed blocks that share one scale, so the block size has to divide the row. A convolution row is `in_channels` times the kernel height times the kernel width, and a ResNet-18 stem gives an odd one. `FakeQuantizer` says so before it writes anything:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6e170b5cdc14",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "group_size=64 does not divide the 147 weights of a row of '0.0': pass a group_size that divides it, or qscheme='per_channel'.\n"
-     ]
-    }
-   ],
-   "source": [
-    "try:\n",
-    "    FakeQuantizer(learners['resnet18'].model, weight_bits=4, act_bits=None,\n",
-    "                  qscheme='per_group', group_size=64)\n",
-    "except ValueError as e:\n",
-    "    print(e)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6ff9fec527b7",
-   "metadata": {},
-   "source": [
-    "Narrowing `layer_type` to the layers whose rows do divide is one way through — here, the two `nn.Linear` layers of the fastai head:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5fe190ea27e9",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "vgg16_bn          96.97% (3806/3925)    11 flips   rounded 529,408/15,239,872 weights = 3.47%\n",
-      "resnet18          95.77% (3759/3925)    13 flips   rounded 529,408/11,696,320 weights = 4.53%\n",
-      "efficientnet_b0   95.36% (3743/3925)    17 flips   rounded 1,315,840/5,272,032 weights = 24.96%\n"
-     ]
-    }
-   ],
-   "source": [
-    "for name, learn in learners.items():\n",
-    "    total = sum(m.weight.numel() for m in learn.model.modules()\n",
-    "                if isinstance(m, (nn.Conv2d, nn.Linear)))\n",
-    "    head = sum(m.weight.numel() for m in learn.model.modules() if isinstance(m, nn.Linear))\n",
-    "    pct, k, n, flips = measure(learn, ref=float_pred[name], weight_bits=4, act_bits=None,\n",
-    "                               qscheme='per_group', group_size=64, layer_type=nn.Linear)\n",
-    "    print(f'{name:<18}{pct:.2f}% ({k}/{n})   {flips:3d} flips   '\n",
-    "          f'rounded {head:,}/{total:,} weights = {100 * head / total:.2f}%')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1bb5eb899352",
-   "metadata": {},
-   "source": [
-    "The fraction rounded is worth reading before the accuracy. On the two convolutional stacks the head is 3.47% and 4.53% of the `Conv2d` and `Linear` weights, so those rows say little. On `efficientnet_b0` it is 24.96% — a quarter of the weights taken to 4 bits in groups of 64, for 95.36% (3743/3925) against a 95.44% (3746/3925) reference and 17 images changing class."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f781b274e8d3",
+   "id": "3c1599446ae6",
    "metadata": {},
    "source": [
     "## One layer held at floating point\n",
     "\n",
-    "`layer_bits` maps a layer name to its own width, and `None` holds that layer in floating point. The first convolution is a common one to hold out, since every later layer reads through it — though it is the smallest tensor in only one of these three models:"
+    "`layer_bits` maps a layer name to its own width, and `None` holds that layer in floating point. Here `'0.0'`, the stem convolution of the fastai body, stays in floating point while the rest of the model goes to 4 bits."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f2142bd29ad",
+   "id": "4cd0a3903e31",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "vgg16_bn          95.39% (3744/3925)   first conv '0.0.0' 1,728 weights   smallest '0.0.0' 1,728\n",
-      "resnet18          92.99% (3650/3925)   first conv '0.0' 9,408 weights   smallest '1.8' 5,120\n",
-      "efficientnet_b0   47.26% (1855/3925)   first conv '0.0.0.0' 864 weights   smallest '0.0.1.0.block.1.fc1' 256\n"
+      "W4 per_channel, '0.0' float   92.25% (3621/3925)   244 flips\n"
      ]
     }
    ],
    "source": [
-    "for name, learn in learners.items():\n",
-    "    named = [(n, m) for n, m in learn.model.named_modules()\n",
-    "             if isinstance(m, (nn.Conv2d, nn.Linear))]\n",
-    "    first = named[0]\n",
-    "    smallest = min(named, key=lambda nm: nm[1].weight.numel())\n",
-    "    pct, k, n, flips = measure(learn, ref=float_pred[name], weight_bits=4, act_bits=None,\n",
-    "                               qscheme='per_channel', layer_bits={first[0]: None})\n",
-    "    print(f'{name:<18}{pct:.2f}% ({k}/{n})   first conv {first[0]!r} {first[1].weight.numel():,} weights   '\n",
-    "          f'smallest {smallest[0]!r} {smallest[1].weight.numel():,}')"
+    "pct, k, n, flips = measure(weight_bits=4, qscheme='per_channel', layer_bits={'0.0': None})\n",
+    "print(f\"W4 per_channel, '0.0' float   {pct:.2f}% ({k}/{n})   {flips} flips\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ca92b0349650",
+   "id": "5e848534afe3",
    "metadata": {},
    "source": [
-    "It is the smallest on `vgg16_bn` at 1,728 weights; on `resnet18` its 9,408 weights are more than the 5,120 of the head's last layer, and on `efficientnet_b0` its 864 are more than the 256 of a squeeze-and-excitation projection.\n",
-    "\n",
-    "Holding it out of the 4-bit rounding moves `vgg16_bn` from 94.39% (3705/3925) to 95.39% (3744/3925), `resnet18` from 89.96% (3531/3925) to 92.99% (3650/3925), and `efficientnet_b0` from 45.35% (1780/3925) to 47.26% (1855/3925). It buys back part of what 4 bits cost on the two convolutional stacks, and leaves `efficientnet_b0` far from its reference."
+    "That moves the 4-bit row from 90.14% (3538/3925) to 92.25% (3621/3925)."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5a14c330f28b",
-   "metadata": {},
-   "source": [
-    "## Where EfficientNet loses it\n",
-    "\n",
-    "The W8A8 row said the activations are what `efficientnet_b0` cannot carry at 8 bits. Hooking every rounded site over the fixed calibration set shows where their ranges are widest:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ffbc84cba044",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0.4.0.block.0.0     [  -595.6,    163.5]  pointwise k=(1, 1) groups=1\n",
-      "0.0.5.0.block.0.0     [  -110.9,    107.8]  pointwise k=(1, 1) groups=1\n",
-      "0.0.3.0.block.0.0     [   -88.6,     88.4]  pointwise k=(1, 1) groups=1\n",
-      "0.0.4.2.block.0.0     [  -103.1,     51.6]  pointwise k=(1, 1) groups=1\n",
-      "0.0.2.0.block.0.0     [   -81.9,     69.6]  pointwise k=(1, 1) groups=1\n",
-      "\n",
-      "first-ranked site on three shuffled five-batch draws from dls.train\n",
-      "  draw 1: 0.0.4.0.block.0.0, 0.0.2.0.block.0.0, 0.0.3.0.block.0.0\n",
-      "  draw 2: 0.0.4.0.block.0.0, 0.0.2.0.block.0.0, 0.0.3.0.block.0.0\n",
-      "  draw 3: 0.0.2.0.block.0.0, 0.0.4.0.block.0.0, 0.0.3.0.block.0.0\n"
-     ]
-    }
-   ],
-   "source": [
-    "eff = learners['efficientnet_b0']\n",
-    "sites = {n: m for n, m in eff.model.named_modules() if isinstance(m, (nn.Conv2d, nn.Linear))}\n",
-    "\n",
-    "def act_ranges(loader, n_batches=5):\n",
-    "    \"Smallest and largest activation each rounded site emits over `n_batches`\"\n",
-    "    seen = {}\n",
-    "    def watch(name):\n",
-    "        def hook(_, inp, out):\n",
-    "            lo, hi = out.detach().amin().item(), out.detach().amax().item()\n",
-    "            if name in seen: lo, hi = min(seen[name][0], lo), max(seen[name][1], hi)\n",
-    "            seen[name] = (lo, hi)\n",
-    "        return hook\n",
-    "    handles = [m.register_forward_hook(watch(n)) for n, m in sites.items()]\n",
-    "    eff.model.eval()\n",
-    "    with torch.no_grad():\n",
-    "        for i, batch in enumerate(loader):\n",
-    "            if i >= n_batches: break\n",
-    "            eff.model(batch[0])\n",
-    "    for h in handles: h.remove()\n",
-    "    return sorted(seen.items(), key=lambda kv: kv[1][1] - kv[1][0], reverse=True)\n",
-    "\n",
-    "widest = act_ranges(calib_dl)\n",
-    "for name, (lo, hi) in widest[:5]:\n",
-    "    m = sites[name]\n",
-    "    kind = 'depthwise' if m.groups == m.in_channels > 1 else 'pointwise' if m.kernel_size == (1, 1) else 'conv'\n",
-    "    print(f'{name:<22}[{lo:8.1f}, {hi:8.1f}]  {kind:<10}k={m.kernel_size} groups={m.groups}')\n",
-    "\n",
-    "print('\\nfirst-ranked site on three shuffled five-batch draws from dls.train')\n",
-    "for draw in range(3):\n",
-    "    print(f'  draw {draw + 1}: ' + ', '.join(n for n, _ in act_ranges(dls.train)[:3]))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c94484101432",
-   "metadata": {},
-   "source": [
-    "On this calibration set the five widest are all 1x1 pointwise convolutions with `groups=1`, the expansion at the head of an inverted-residual block, and the widest runs from -595.6 to 163.5. One 8-bit grid stretched over that span leaves little resolution for the values near zero, which is most of them.\n",
-    "\n",
-    "The ranking is a property of the data, not of the model alone: the three shuffled draws printed above do not agree on which site is widest. Read it as one observation from one calibration set.\n",
-    "\n",
-    "`layer_act_bits` holds named sites at floating point the way `layer_bits` does for weights:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0ba8419f3d88",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 0 sites in floating point: 64.36% (2526/3925)   1386 flips\n",
-      " 1 sites in floating point: 63.82% (2505/3925)   1408 flips\n",
-      " 3 sites in floating point: 64.48% (2531/3925)   1385 flips\n",
-      " 5 sites in floating point: 64.15% (2518/3925)   1391 flips\n",
-      "10 sites in floating point: 80.08% (3143/3925)   773 flips\n",
-      "20 sites in floating point: 80.79% (3171/3925)   724 flips\n"
-     ]
-    }
-   ],
-   "source": [
-    "for k_sites in (0, 1, 3, 5, 10, 20):\n",
-    "    pct, k, n, flips = measure(eff, ref=float_pred['efficientnet_b0'],\n",
-    "                               weight_bits=8, act_bits=8, qscheme='per_channel',\n",
-    "                               layer_act_bits={name: None for name, _ in widest[:k_sites]} or None)\n",
-    "    print(f'{k_sites:2d} sites in floating point: {pct:.2f}% ({k}/{n})   {flips} flips')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2af9f083efe0",
-   "metadata": {},
-   "source": [
-    "This does not behave the way the ranking suggests. Holding out the single widest site gives 2505/3925 correct against 2526/3925 for holding out none — slightly worse — and 3 and 5 sites give 2531/3925 and 2518/3925. All four sit inside the calibration spread measured in the next section, so the first five sites change nothing this page can resolve. The move appears at 10 sites, 80.08% (3143/3925), and barely grows at 20, 80.79% (3171/3925), still well short of the 95.44% (3746/3925) the model starts from.\n",
-    "\n",
-    "So the widest-range ranking does not locate the damage: holding out the top of it is not what recovers the model, and twenty sites in floating point do not undo what 8-bit activations cost this architecture."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "07b3bb0a5f71",
-   "metadata": {},
-   "source": [
-    "## What the calibration set decides\n",
-    "\n",
-    "Every static row above used one fixed calibration set. Repeating a single configuration on five shuffled, augmented draws from `dls.train` shows what that choice was worth:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2ccb8120ac19",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "draw 1: 48.31% (1896/3925)\n",
-      "draw 2: 49.43% (1940/3925)\n",
-      "draw 3: 50.93% (1999/3925)\n",
-      "draw 4: 50.27% (1973/3925)\n",
-      "draw 5: 48.97% (1922/3925)\n",
-      "spread over five shuffled draws: 103 images = 2.62 points\n",
-      "the fixed calibration set gives:  64.36% (2526/3925)\n"
-     ]
-    }
-   ],
-   "source": [
-    "draws = [measure(eff, weight_bits=8, act_bits=8, qscheme='per_channel', calib=dls.train)\n",
-    "         for _ in range(5)]\n",
-    "for i, (pct, k, n, _) in enumerate(draws):\n",
-    "    print(f'draw {i + 1}: {pct:.2f}% ({k}/{n})')\n",
-    "ks = [k for _, k, _, _ in draws]\n",
-    "fixed = rows['W8A8 static, per_channel']['efficientnet_b0']\n",
-    "print(f'spread over five shuffled draws: {max(ks) - min(ks)} images '\n",
-    "      f'= {100 * (max(ks) - min(ks)) / N:.2f} points')\n",
-    "print(f'the fixed calibration set gives:  {fixed[0]:.2f}% ({fixed[1]}/{fixed[2]})')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b37c2ebf6415",
-   "metadata": {},
-   "source": [
-    "Two things. The five shuffled draws spread over 103 images, 2.62 points, purely from which batches were drawn — that is the noise floor for every A8 number on this page, and no conclusion here rests on an A8 difference smaller than it. The weights-versus-activations contrast clears it by a wide margin, 3744/3925 against 2526/3925; the first four rows of the activation sweep above do not clear it at all.\n",
-    "\n",
-    "Second, the fixed calibration set does not land inside that spread: 64.36% (2526/3925) against draws running from 48.31% (1896/3925) to 50.93% (1999/3925). The fixed set applies validation-style preprocessing while `dls.train` applies training augmentation, so the two observe different activation ranges. Which data the scales are frozen on moved this configuration further than any draw did."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "071acd5ae9b1",
+   "id": "f739bb1fbcc9",
    "metadata": {},
    "source": [
     "---\n",
@@ -857,28 +444,18 @@
     "| Call | What it does |\n",
     "|---|---|\n",
     "| `FakeQuantizer(model, weight_bits=8, act_bits=8)` | a quantizer bound to this model; `None` on either width leaves those tensors in floating point |\n",
-    "| `fq.calibrate(calib_dl, n_batches=5)` | observes activation ranges and freezes the static scales; takes a fastai `DataLoaders` or one of its loaders |\n",
+    "| `fq.calibrate(calib_dl, n_batches=5)` | observes the activation ranges and freezes the static scales |\n",
     "| `fq.quantize_model()` | rounds the weights in place and hooks the activations |\n",
     "| `fq.remove()` | restores the floating-point weights and drops every hook and buffer |\n",
     "| `fq.print_precision()` | the per-layer width report |\n",
-    "| `qscheme='per_tensor'` / `'per_channel'` / `'per_group'` | one scale for the tensor, one per output row, or one per block of a row |\n",
-    "| `group_size=64` | the block size `per_group` shares a scale over; it has to divide the row |\n",
-    "| `layer_type=nn.Linear` | narrows the modules that carry the rounding; the default is `(nn.Conv2d, nn.Linear)` |\n",
-    "| `layer_bits={name: None}` | one weight width per layer, `None` holding it at floating point |\n",
-    "| `layer_act_bits={name: None}` | the same, for that layer's activations |\n",
-    "| `observer='dynamic'` | recomputes activation scales per batch instead of freezing them; not exercised on this page |\n",
+    "| `layer_bits={'0.0': None}` | one weight width per layer, `None` holding that layer in floating point |\n",
     "\n",
-    "What this page measured, and what it did not: accuracy and changed predictions, on three models, one fine-tune each. `FakeQuantizer` does not make the model smaller; when `act_bits` is set it adds a rounding op to every hooked activation, and this page does not measure latency.\n",
-    "\n",
-    "> **Measured on:** Imagenette-160, 9469 training images and 3925 validation images, at 160 pixels with batch size 32, on the torch build and device printed at the top of the page. One `fine_tune(1)` per architecture under `set_seed(42, reproducible=True)`, then one `learn.validate()` per configuration on the same 3925 images. Static rows share one fixed 5-batch calibration set built with `dls.test_dl`; the measured draw-to-draw spread of an A8 row is 103 images, 2.62 points. Single run throughout: no repetition and no dispersion beyond that calibration spread. Every accuracy carries its k/n, and the Wilson intervals are printed for the three references only.\n",
+    "> **Measured on:** Imagenette-160, 9469 training images and 3925 validation images at 160 pixels, on the torch build and device printed at the top of the page. One `fine_tune(1)` under `set_seed(42, reproducible=True)`, then one `learn.validate()` per configuration on the same 3925 images, and one fixed five-batch calibration set for the static rows. Single run: no repetition, and no dispersion beyond the Wilson interval printed for the reference.\n",
     "\n",
     "## See Also\n",
     "\n",
     "- [FakeQuantizer API](../../quantize/fake_quantizer.html) - the class, its arguments and its refusals\n",
-    "- [Precision grammar](../../core/precision.html) - the widths and axes fasterai names, and which backends run them\n",
-    "- [Quantizer](../../quantize/quantizer.html) - the backends that produce a model that is actually smaller\n",
-    "- [Quantization Methods Compared](quantization_compared.html) - size and latency of real quantized models\n",
-    "- [Deployable Export](deployable_export.html) - exporting a quantized model and checking what came out\n",
+    "- [Precision grammar](../../core/precision.html) - the widths and axes fasterai names\n",
     "- [BN Folding](../misc/bn_folding.html) - folding batch norm into the convolution ahead of it"
    ]
   }


### PR DESCRIPTION
## Why

The FakeQuantizer tutorial ran three architectures through eight configurations, groups, dead filters, a site analysis and calibration draws: a measurement, not a page that shows the API. And its setup had two defects: `calib_dl` was built before `vision_learner` added `Normalize` to the loader, so every static row calibrated on unnormalized batches and validated on normalized ones; and the loader was built with no seed, so the fine-tune was not reproducible.

## The page now

Ten code cells on one fine-tuned ResNet-18, one seed, executed once: round the weights (accuracy, flips, `print_precision`, `remove()` byte for byte), three widths, the activations too, per-channel against per-tensor at 4 bits with the count of distinct values per output channel, one layer held in floating point. `Normalize` is named in the loader and a guard prints both pipelines; `set_seed` precedes the loader.

Rows, single run, n = 3925:

```
floating point   96.28% (3779/3925)
W8 per_channel   96.25% (3778/3925)     8 flips
W4 per_channel   90.14% (3538/3925)   332 flips
W2 per_channel   10.42% (409/3925)   3524 flips
W8A8 static      96.13% (3773/3925)    30 flips
W4A8 static      90.01% (3533/3925)   335 flips
W4 per_tensor    24.23% (951/3925)   2976 flips
```

Against the old page's ResNet-18 rows (W8A8 95.34 %, W4A8 88.92 %), calibrating on the normalized pipeline is worth about a point: the old activation rows were biased low. The EfficientNet and VGG rows are no longer on the page.
