### PR TITLE
docs(quantize): FakeQuantizeCallback tutorial

### DIFF
--- a/nbs/_quarto.yml
+++ b/nbs/_quarto.yml
@@ -78,6 +78,7 @@ website:
           - tutorials/quantize/deployable_export.ipynb
           - tutorials/quantize/quantization_compared.ipynb
           - tutorials/quantize/fake_quantizer.ipynb
+          - tutorials/quantize/fake_quantize_callback.ipynb
         - section: Misc
           contents:
           - tutorials/misc/bn_folding.ipynb

--- a/nbs/quantize/fake_quantize_callback.ipynb
+++ b/nbs/quantize/fake_quantize_callback.ipynb
@@ -662,6 +662,7 @@
     "\n",
     "## See Also\n",
     "\n",
+    "- [FakeQuantizeCallback tutorial](../tutorials/quantize/fake_quantize_callback.html) - One measured run of the width ladder against training at the target width\n",
     "- [FakeQuantizer](fake_quantizer.html) - The same arithmetic, applied after training\n",
     "- [Parametrize](../core/parametrize.html) - The master weight behind a parametrized module\n",
     "- [QuantizeCallback](quantize_callback.html) - QAT that produces a model running at reduced precision\n",

--- a/nbs/tutorial_contract.ipynb
+++ b/nbs/tutorial_contract.ipynb
@@ -1301,7 +1301,7 @@
     "\n",
     "UNLISTED_OK: frozenset[str] = frozenset()          # pages allowed to be absent from the sidebar\n",
     "LEXICON_ALLOW: dict[str, frozenset[str]] = {}      # page -> sentences allowed under R5, verbatim\n",
-    "N_PAGES = 21                                       # pinned: a page added or lost is a review event"
+    "N_PAGES = 22                                       # pinned: a page added or lost is a review event"
    ]
   },
   {

--- a/nbs/tutorials/quantize/fake_quantize_callback.ipynb
+++ b/nbs/tutorials/quantize/fake_quantize_callback.ipynb
@@ -1,0 +1,465 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "id": "7e15b7f85609",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "description: Quantization-aware training on FakeQuantizer's arithmetic, through fastai\n",
+    "output-file: tutorial.fake_quantize_callback.html\n",
+    "title: FakeQuantizeCallback\n",
+    "skip_showdoc: true\n",
+    "skip_exec: true\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98a3a8c3a1ff",
+   "metadata": {},
+   "source": [
+    "`FakeQuantizeCallback` trains a model *through* the rounding it will be subject to. On every forward the\n",
+    "weights are rounded onto the grid of the width you asked for and, when `act_bits` is set, so is every\n",
+    "rounded layer's output. The loss is computed on the rounded model, and the gradient reaches an untouched\n",
+    "floating-point copy which the optimizer keeps training. When the fit ends the rounding is baked in, and\n",
+    "what is left is an ordinary model holding rounded weights.\n",
+    "\n",
+    "The accuracy it measures is *simulated*: the model keeps its `float32` tensors, it is not smaller, it is\n",
+    "not quicker, and nothing on this page measures a latency."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36fbd5ce311a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| include: false\n",
+    "import contextlib, io, math, warnings\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "with contextlib.redirect_stderr(io.StringIO()):   # torchao writes an import banner to stderr\n",
+    "    import fasterai.quantize.quantize_callback\n",
+    "\n",
+    "def wilson(k, n, z=1.96):\n",
+    "    \"Wilson 95% interval for k of n, as percentages\"\n",
+    "    p, d = k / n, 1 + z * z / n\n",
+    "    c = (p + z * z / (2 * n)) / d\n",
+    "    h = z / d * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n))\n",
+    "    return 100 * max(0., c - h), 100 * min(1., c + h)\n",
+    "\n",
+    "def score(learn):\n",
+    "    \"Validation accuracy of `learn`, as a percentage and as k/n\"\n",
+    "    with learn.no_bar():\n",
+    "        acc = float(learn.validate()[1])\n",
+    "    k = round(acc * N)\n",
+    "    return 100 * k / N, k, N\n",
+    "\n",
+    "def report(label, s):\n",
+    "    \"One line: the accuracy as a percentage, as k/n, and with its Wilson interval\"\n",
+    "    lo, hi = wilson(s[1], s[2])\n",
+    "    print(f'{label:<34}{s[0]:.2f}% ({s[1]}/{s[2]})   Wilson 95% [{lo:.2f}, {hi:.2f}]')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "384eb7f7efb2",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Imagenette at 160 pixels and one `resnet18`, fine-tuned for one cycle. `fresh()` gives every section\n",
+    "that same checkpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b27f820977e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch 2.9.1+cu128 on NVIDIA GeForce RTX 5090\n"
+     ]
+    }
+   ],
+   "source": [
+    "import io, torch\n",
+    "from fastai.vision.all import *\n",
+    "from fasterai.core.precision import fake_quant_spec\n",
+    "from fasterai.core.schedule import lin\n",
+    "from fasterai.quantize.fake_quantizer import FakeQuantizer\n",
+    "from fasterai.quantize.fake_quantize_callback import FakeQuantizeCallback\n",
+    "\n",
+    "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
+    "print(f'torch {torch.__version__} on '\n",
+    "      f'{torch.cuda.get_device_name(0) if device == \"cuda\" else \"cpu\"}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b923533b58d8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "9469 training images, 3925 validation images, calibration set of 5 batches\n"
+     ]
+    }
+   ],
+   "source": [
+    "path = untar_data(URLs.IMAGENETTE_160)\n",
+    "\n",
+    "def make_dls():\n",
+    "    \"Imagenette at 160 pixels; `Normalize` is named here rather than left to `vision_learner`\"\n",
+    "    return ImageDataLoaders.from_folder(path, valid='val', item_tfms=Resize(160), bs=32,\n",
+    "                                        batch_tfms=Normalize.from_stats(*imagenet_stats))\n",
+    "\n",
+    "set_seed(42, reproducible=True)\n",
+    "dls = make_dls()\n",
+    "N = len(dls.valid_ds)\n",
+    "\n",
+    "# fixed calibration set\n",
+    "files = sorted(get_image_files(path/'train'))\n",
+    "calib_dl = dls.test_dl(files[::len(files)//160][:160], bs=32)\n",
+    "\n",
+    "print(f'{len(dls.train_ds)} training images, {N} validation images, '\n",
+    "      f'calibration set of {len(calib_dl)} batches')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8fd8c8be2b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fine-tuned, floating point        96.28% (3779/3925)   Wilson 95% [95.64, 96.83]\n"
+     ]
+    }
+   ],
+   "source": [
+    "set_seed(42, reproducible=True)\n",
+    "learn = vision_learner(dls, resnet18, metrics=accuracy)\n",
+    "with learn.no_bar(), learn.no_logging():\n",
+    "    learn.fine_tune(1)\n",
+    "CHECKPOINT = {k: v.detach().clone() for k, v in learn.model.state_dict().items()}\n",
+    "\n",
+    "def fresh():\n",
+    "    \"That checkpoint in a learner of its own, unfrozen, with its loaders seeded the same way\"\n",
+    "    set_seed(0, reproducible=True)\n",
+    "    l = vision_learner(make_dls(), resnet18, metrics=accuracy)\n",
+    "    l.model.load_state_dict(CHECKPOINT)\n",
+    "    l.unfreeze()\n",
+    "    return l\n",
+    "\n",
+    "FLOAT = score(learn)\n",
+    "report('fine-tuned, floating point', FLOAT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a342ee485373",
+   "metadata": {},
+   "source": [
+    "## Train through the rounding\n",
+    "\n",
+    "`FakeQuantizeCallback(weight_bits=4, act_bits=8)` rounds every `Conv2d` and `Linear` weight to 4 bits,\n",
+    "one scale per output channel, and the output of each of those layers to 8 bits. The fit is an ordinary\n",
+    "`fit_one_cycle`: the callback says what it is training through when the fit starts, and what it baked\n",
+    "when the fit ends."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93740d076105",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training through W4A8, weights per_channel\n",
+      "Baked in W4A8: the model holds its rounded weights, and fake_quantizer.remove() gives the trained floating-point ones back\n",
+      "W4A8, trained through it          92.59% (3634/3925)   Wilson 95% [91.72, 93.36]\n"
+     ]
+    }
+   ],
+   "source": [
+    "learn = fresh()\n",
+    "cb = FakeQuantizeCallback(weight_bits=4, act_bits=8)\n",
+    "with learn.no_bar(), learn.no_logging():\n",
+    "    learn.fit_one_cycle(3, 1e-3, cbs=[cb])\n",
+    "\n",
+    "QAT = score(learn)\n",
+    "report('W4A8, trained through it', QAT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bde855f9bc8e",
+   "metadata": {},
+   "source": [
+    "`print_precision()` names the width every layer carries, and the spec the model comes out with says\n",
+    "`trained=True` — which a post-training spec does not."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07121ed60d23",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Simulated Precision Report:\n",
+      "--------------------------------------------------------------------------------\n",
+      "Layer                            Type           Weight     Act        Weight axis \n",
+      "--------------------------------------------------------------------------------\n",
+      "0.0                              Conv2d         4 bits     8 bits     per_channel \n",
+      "0.4.0.conv1                      Conv2d         4 bits     8 bits     per_channel \n",
+      "0.4.0.conv2                      Conv2d         4 bits     8 bits     per_channel \n",
+      "0.4.1.conv1                      Conv2d         4 bits     8 bits     per_channel \n",
+      "0.4.1.conv2                      Conv2d         4 bits     8 bits     per_channel \n",
+      "0.5.0.conv1                      Conv2d         4 bits     8 bits     per_channel \n",
+      "0.5.0.conv2                      Conv2d         4 bits     8 bits     per_channel \n",
+      "0.5.0.downsample.0               Conv2d         4 bits     8 bits     per_channel \n",
+      "0.5.1.conv1                      Conv2d         4 bits     8 bits     per_channel \n",
+      "0.5.1.conv2                      Conv2d         4 bits     8 bits     per_channel \n",
+      "0.6.0.conv1                      Conv2d         4 bits     8 bits     per_channel \n",
+      "0.6.0.conv2                      Conv2d         4 bits     8 bits     per_channel \n",
+      "0.6.0.downsample.0               Conv2d         4 bits     8 bits     per_channel \n",
+      "0.6.1.conv1                      Conv2d         4 bits     8 bits     per_channel \n",
+      "0.6.1.conv2                      Conv2d         4 bits     8 bits     per_channel \n",
+      "0.7.0.conv1                      Conv2d         4 bits     8 bits     per_channel \n",
+      "0.7.0.conv2                      Conv2d         4 bits     8 bits     per_channel \n",
+      "0.7.0.downsample.0               Conv2d         4 bits     8 bits     per_channel \n",
+      "0.7.1.conv1                      Conv2d         4 bits     8 bits     per_channel \n",
+      "0.7.1.conv2                      Conv2d         4 bits     8 bits     per_channel \n",
+      "1.4                              Linear         4 bits     8 bits     per_channel \n",
+      "1.8                              Linear         4 bits     8 bits     per_channel \n",
+      "--------------------------------------------------------------------------------\n",
+      "Overall                          W4A8          \n",
+      "Rounded in floating point: every tensor is still stored at its original width, and the model holds a floating-point copy of every weight it rounds until remove().\n",
+      "\n",
+      "spec W4A8   qscheme per_channel   trained True\n"
+     ]
+    }
+   ],
+   "source": [
+    "cb.fake_quantizer.print_precision()\n",
+    "\n",
+    "spec = fake_quant_spec(learn.model)\n",
+    "print(f'\\nspec {spec.label}   qscheme {spec.qscheme}   trained {spec.trained}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fd0dc795d00",
+   "metadata": {},
+   "source": [
+    "## The same width, without the training\n",
+    "\n",
+    "The same widths applied to the same checkpoint *after* training rather than during it:\n",
+    "[`FakeQuantizer`](fake_quantizer.html) observes the activation ranges on the fixed calibration set, then\n",
+    "rounds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c38bb19c02f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "W4A8, rounded after training      89.96% (3531/3925)   Wilson 95% [88.98, 90.86]\n",
+      "difference against the fit above: +103 validation images of 3925\n"
+     ]
+    }
+   ],
+   "source": [
+    "ptq_learn = fresh()\n",
+    "fq = FakeQuantizer(ptq_learn.model, weight_bits=4, act_bits=8)\n",
+    "fq.calibrate(calib_dl)\n",
+    "fq.quantize_model()\n",
+    "\n",
+    "PTQ = score(ptq_learn)\n",
+    "report('W4A8, rounded after training', PTQ)\n",
+    "print(f'difference against the fit above: {QAT[1] - PTQ[1]:+d} validation images of {N}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bb724c59f42",
+   "metadata": {},
+   "source": [
+    "In this single run the fit that trained through the rounding ends 103 validation images of 3925 above\n",
+    "the one rounded afterwards — 92.59% (3634/3925) against 89.96% (3531/3925). The two do not cost the\n",
+    "same: the fit carries three epochs of training and this row carries none."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab15f042fac6",
+   "metadata": {},
+   "source": [
+    "## Lower the width during the fit\n",
+    "\n",
+    "`weight_schedule` and `weight_widths` step the width down during the fit instead of rounding at the\n",
+    "target from the first batch. The rungs share the [`Schedule`](../../core/schedules.html)'s progress\n",
+    "equally, so three rungs over three epochs spend about one epoch each. `act_schedule` and `act_widths` do\n",
+    "the same for the activations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11cd999a7405",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ShowWidths(Callback):\n",
+    "    \"The widths the fit is rounding at, once per epoch\"\n",
+    "    def __init__(self, cb): self.cb = cb\n",
+    "    def after_epoch(self): print(f'  end of epoch {self.epoch}: {self.cb.current_widths}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f22e2b0c0e40",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training through W4A8, weights per_channel, stepping weight through [16, 8, 4] bits\n",
+      "  end of epoch 0: {'weight': 16, 'act': 8}\n",
+      "  end of epoch 1: {'weight': 8, 'act': 8}\n",
+      "  end of epoch 2: {'weight': 4, 'act': 8}\n",
+      "Baked in W4A8: the model holds its rounded weights, and fake_quantizer.remove() gives the trained floating-point ones back\n",
+      "W4A8 down a 16 -> 8 -> 4 ladder   92.28% (3622/3925)   Wilson 95% [91.40, 93.07]\n",
+      "difference against the fit that started at 4 bits: -12 validation images of 3925\n",
+      "spec W4A8   weight_widths (16, 8, 4)\n"
+     ]
+    }
+   ],
+   "source": [
+    "learn = fresh()\n",
+    "cb = FakeQuantizeCallback(weight_bits=4, act_bits=8, weight_schedule=lin, weight_widths=(16, 8, 4))\n",
+    "with learn.no_bar(), learn.no_logging():\n",
+    "    learn.fit_one_cycle(3, 1e-3, cbs=[cb, ShowWidths(cb)])\n",
+    "\n",
+    "LADDER = score(learn)\n",
+    "report('W4A8 down a 16 -> 8 -> 4 ladder', LADDER)\n",
+    "print(f'difference against the fit that started at 4 bits: {LADDER[1] - QAT[1]:+d} '\n",
+    "      f'validation images of {N}')\n",
+    "\n",
+    "spec = fake_quant_spec(learn.model)\n",
+    "print(f'spec {spec.label}   weight_widths {spec.weight_widths}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "106346310855",
+   "metadata": {},
+   "source": [
+    "The widths step down one rung per epoch, and the spec records the ladder that was asked for next to the\n",
+    "width the model ended at. In this single run, on one architecture and one seed, the ladder ended 12\n",
+    "validation images of 3925 below the fit that started at 4 bits — 92.28% (3622/3925) against 92.59%\n",
+    "(3634/3925). Whether lowering the width during a fit is worth doing is not measured here: at equal\n",
+    "epochs a ladder also spends part of its training at a wider width, so the two fits differ in more than\n",
+    "the transition."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3819e230ec2",
+   "metadata": {},
+   "source": [
+    "## What the fit leaves\n",
+    "\n",
+    "An ordinary model. `bake()` runs on its own when the fit ends, so nothing has to be called; the weights\n",
+    "are the rounded ones, still `float32`, and `torch.save` takes the model as it is."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "757c118923aa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "still an ordinary module: Sequential, weights in torch.float32\n"
+     ]
+    }
+   ],
+   "source": [
+    "torch.save(learn.model, io.BytesIO())   # a model still carrying parametrizations would refuse\n",
+    "print(f'still an ordinary module: {type(learn.model).__name__}, '\n",
+    "      f'weights in {next(learn.model.parameters()).dtype}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f77c1c77dae4",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "| Call | What it does |\n",
+    "|---|---|\n",
+    "| `FakeQuantizeCallback(weight_bits=4, act_bits=8)` | trains through W4A8; `None` on either width leaves those tensors in floating point |\n",
+    "| `weight_schedule=lin, weight_widths=(16, 8, 4)` | steps the weight width down during the fit, the rungs sharing the schedule's progress equally; `act_schedule` and `act_widths` do the same for the activations |\n",
+    "| `fake_quant_spec(model)` | the widths the model carries, `trained=True`, and the ladder that was asked for |\n",
+    "| `cb.bake()` / `cb.strip()` | `bake()` runs when the fit ends; after a fit that raised, call one of them by hand |\n",
+    "\n",
+    "> **Measured on:** Imagenette-160, 9469 training images and 3925 validation images at 160 pixels, batch\n",
+    "> size 32, on the torch build and device printed at the top of the page. One `fine_tune(1)` under\n",
+    "> `set_seed(42, reproducible=True)`, then one `fit_one_cycle(3, 1e-3)` per section on the unfrozen model\n",
+    "> under `set_seed(0, reproducible=True)`, and one `learn.validate()` per row on the same 3925 images.\n",
+    "> Single run, one architecture, one seed: no dispersion is quoted anywhere on this page, and every\n",
+    "> difference quoted above is one run against one run. Every accuracy is simulated in floating\n",
+    "> point.\n",
+    "\n",
+    "## See Also\n",
+    "\n",
+    "- [FakeQuantizeCallback API](../../quantize/fake_quantize_callback.html) - the callback, its arguments and its refusals\n",
+    "- [FakeQuantizer](fake_quantizer.html) - the same arithmetic applied after training, and what each width costs three models\n",
+    "- [Schedules](../../core/schedules.html) - the `Schedule` a width ladder reads its progress from"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Stacked on #79, the lazy-probe fix (the page runs at torch's default numerics and prints the device it ran on).

## The page

`tutorials/quantize/fake_quantize_callback.ipynb`: ten code cells, one fine-tuned ResNet-18 on Imagenette, one seed, sixty seconds of GPU. It shows the callback and nothing else: a fit through the rounding at W4A8 and what it leaves (`print_precision`, the spec with `trained=True`); the same width rounded after training, for the difference in images; a width ladder `16 -> 8 -> 4` driven by `lin`, with the width printed at the end of each epoch and the ladder recorded on the spec; `bake()` and `strip()`. Every number in prose is printed by a cell, every accuracy carries k/n, the scope is "single run". `N_PAGES` in the tutorial contract goes 21 -> 22; the API page's See Also links the tutorial.

## What backs the docstring's "not measured here"

The width ladder shipped in #78 with the sentence "whether that is worth doing is not measured here" pinned by a test. A pre-registered experiment (protocol frozen before the first fit; seven arms x two architectures x three seeds; W4A8 per-channel; equal budget for every trained arm; verdict rule fixed in advance) was run to know. It is evidence for this PR, not a page:

| arm, mean of 3 seeds, n = 3925 | resnet18 | efficientnet_b0 |
|---|---|---|
| float, starting checkpoint (no budget) | 96.28 % | 95.62 % |
| PTQ W4A8 (no budget) | 90.01 % | 21.15 % |
| float trained 3 more epochs (control, same budget) | 92.91 % | 96.89 % |
| direct W4A8 | 92.76 % | 95.41 % |
| ladder on weights 16 -> 8 -> 4 | 92.51 % | 95.01 % |
| ladder on activations 16 -> 8 | 92.88 % | 94.96 % |
| both ladders | 92.61 % | 94.77 % |

The rule (a ladder beats direct only if its gain in mean exceeds the larger seed-to-seed spread of the two arms, on both architectures) returns **not distinguished** on both architectures, for all three ladders, in every one of the five runs the experiment went through. On EfficientNet every ladder sits below direct by more than its bar; the rule is one-sided, so that is recorded and not a verdict. Between the run at `'high'` float32 matmul precision and the one at `'highest'`, the sign of the ResNet-18 difference flipped (+0.35 to -0.25 points) while staying inside the bar both times: the effect under test is smaller than that numerics choice, which is how the probe defect under this PR was found. The named confound: at equal epochs a ladder spends part of training at a higher width, so the contrast is "a gentler transition" against "more time at the target width". PTQ carries no training budget and is a reference, not a competitor.

The page's two seed-0 rows (3634 and 3622 correct of 3925) are the experiment's seed-0 rows, obtained in a separate process.
