### PR TITLE
docs: restore the walkthrough's narrative on the current API

### DIFF
--- a/nbs/tutorials/walkthrough.ipynb
+++ b/nbs/tutorials/walkthrough.ipynb
@@ -2,11 +2,11 @@
  "cells": [
   {
    "cell_type": "raw",
-   "id": "wk000",
+   "id": "9788ac491132",
    "metadata": {},
    "source": [
     "---\n",
-    "description: One model from a fine-tune to a deployable INT8 ONNX file\n",
+    "description: Walkthrough\n",
     "output-file: tutorial.walkthrough.html\n",
     "title: Walkthrough\n",
     "skip_showdoc: true\n",
@@ -17,1014 +17,1788 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wk001",
+   "id": "a785a63ba1fb",
    "metadata": {},
    "outputs": [],
    "source": [
     "#| include: false\n",
-    "import os, logging, warnings, contextlib, io\n",
-    "os.environ['TQDM_DISABLE'] = '1'\n",
+    "\n",
+    "import warnings\n",
     "warnings.filterwarnings('ignore')\n",
-    "warnings.filterwarnings('error', message='.*looks like a percent.*')\n",
-    "logging.getLogger('torch.onnx._internal.exporter._schemas').setLevel(logging.ERROR)\n",
-    "with contextlib.redirect_stderr(io.StringIO()):\n",
-    "    try: import torchao  # noqa: F401\n",
-    "    except Exception: pass"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "wk002",
-   "metadata": {},
-   "source": [
-    "## Overview\n",
     "\n",
-    "One model through the four steps fasterai composes: `SparsifyCallback` zeroes weights during training,\n",
-    "`Pruner` removes filters, `Quantizer` lowers the arithmetic to INT8, `export_qdq` writes an ONNX file a\n",
-    "runtime can read. Every measured number below is printed by a cell on this page."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "wk003",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import io, os, time\n",
     "from fastai.vision.all import *\n",
-    "from fasterai.sparse.all import *\n",
-    "from fasterai.prune.all import *\n",
-    "from fasterai.core.all import quant_spec\n",
-    "from fasterai.quantize.quantizer import Quantizer\n",
-    "from fasterai.export.all import export_onnx, export_qdq, qdq_stats, verify_qdq, ONNXModel\n",
     "\n",
-    "import tempfile, torch_pruning as tp\n",
-    "from math import sqrt\n",
+    "def get_num_parameters(model):\n",
+    "    \"Number of parameters in a model, counted over its state_dict\"\n",
+    "    total = 0\n",
+    "    for v in model.state_dict().values():\n",
+    "        # a quantized Linear keeps its weight and bias packed in a tuple\n",
+    "        if torch.is_tensor(v): total += v.numel()\n",
+    "        elif isinstance(v, tuple): total += sum(t.numel() for t in v if torch.is_tensor(t))\n",
+    "    return total\n",
     "\n",
-    "tmp = Path(tempfile.mkdtemp())   # every file this page writes goes here"
+    "def get_model_size(model):\n",
+    "    \"Disk size in bytes of a model, as the bytes torch writes for it on the CPU\"\n",
+    "    buf = io.BytesIO()\n",
+    "    if isinstance(model, torch.jit.ScriptModule): torch.jit.save(model, buf)\n",
+    "    else:\n",
+    "        torch.save({k: v.cpu() if torch.is_tensor(v) else v\n",
+    "                    for k, v in model.state_dict().items()}, buf)\n",
+    "    return len(buf.getvalue())\n",
+    "\n",
+    "LOADS = []\n",
+    "\n",
+    "def evaluate_cpu_speed(model, sample, warmup=10, runs=50, repeats=3):\n",
+    "    \"Milliseconds of one single-image forward pass on the CPU: (mean, min, max) of three repeats\"\n",
+    "    device = next((p.device for p in model.parameters()), torch.device('cpu'))\n",
+    "    model, sample, times = model.to('cpu').eval(), sample.cpu(), []\n",
+    "    with torch.no_grad():\n",
+    "        for _ in range(warmup): model(sample)\n",
+    "        LOADS.append(os.getloadavg()[0])\n",
+    "        for _ in range(repeats):\n",
+    "            t0 = time.perf_counter()\n",
+    "            for _ in range(runs): model(sample)\n",
+    "            times.append((time.perf_counter() - t0) * 1000 / runs)\n",
+    "    model.to(device)\n",
+    "    return sum(times) / len(times), min(times), max(times)\n",
+    "\n",
+    "def count_agreement(a, b, dls):\n",
+    "    \"Validation images on which two models predict the same class\"\n",
+    "    a.eval(); b.eval()\n",
+    "    same = 0\n",
+    "    with torch.no_grad():\n",
+    "        for xb, yb in dls.valid:\n",
+    "            xb = xb.cpu()\n",
+    "            same += int((a(xb).argmax(dim=-1) == b(xb).argmax(dim=-1)).sum())\n",
+    "    return same\n",
+    "\n",
+    "def report_accuracy(model, name, dls):\n",
+    "    \"Print the validation accuracy of a model as k/n, and return (k, n)\"\n",
+    "    device = next((p.device for p in model.parameters()), torch.device('cpu'))\n",
+    "    model.eval()\n",
+    "    k = n = 0\n",
+    "    with torch.no_grad():\n",
+    "        for xb, yb in dls.valid:\n",
+    "            pred = model(xb.to(device)).argmax(dim=-1)\n",
+    "            k += int((pred == yb.to(device)).sum()); n += len(yb)\n",
+    "    print(f'{name} accuracy: {k}/{n} ({k/n:.2%})')\n",
+    "    return k, n\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wk003b",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "torch 2.9.1+cu128 | onnx 1.17.0 | onnxruntime 1.24.1 | training on cuda:0\n"
-     ]
-    }
-   ],
-   "source": [
-    "import onnx, onnxruntime\n",
-    "print(f\"torch {torch.__version__} | onnx {onnx.__version__} | onnxruntime {onnxruntime.__version__} \"\n",
-    "      f\"| training on {default_device()}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "wk004",
-   "metadata": {},
-   "source": [
-    "## 1. Data and baseline\n",
-    "\n",
-    "The cat/dog labels of the PETS dataset, images resized to 64 px."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "wk005",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5912 training images, 1478 validation images, majority class 66.91%\n"
-     ]
-    }
-   ],
-   "source": [
-    "path = untar_data(URLs.PETS)\n",
-    "files = get_image_files(path/\"images\")\n",
-    "\n",
-    "def label_func(f): return f[0].isupper()\n",
-    "\n",
-    "dls = ImageDataLoaders.from_name_func(path, files, label_func, item_tfms=Resize(64))\n",
-    "\n",
-    "labels = [label_func(f.name) for f in dls.valid.items]\n",
-    "print(f\"{len(dls.train_ds)} training images, {len(dls.valid_ds)} validation images, majority class \"\n",
-    "      f\"{max(sum(labels), len(labels)-sum(labels))/len(labels):.2%}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "wk007",
+   "id": "0ce2ec36f911",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def report(learn, name):\n",
-    "    \"Validation accuracy with its Wilson 95% interval\"\n",
-    "    n = len(learn.dls.valid_ds)\n",
-    "    with learn.no_bar(): acc = float(learn.validate()[1])\n",
-    "    k, z = round(acc*n), 1.96\n",
-    "    p, d = k/n, 1 + z**2/n\n",
-    "    c = p + z**2/(2*n)\n",
-    "    h = z*sqrt(p*(1-p)/n + z**2/(4*n**2))\n",
-    "    print(f\"{name}: {acc:.2%} ({k}/{n}), Wilson 95% [{(c-h)/d:.2%}, {(c+h)/d:.2%}]\")\n",
-    "    return acc\n",
+    "#| include: false\n",
     "\n",
-    "stages = []\n",
+    "def get_dls(size, bs):\n",
+    "    path = URLs.IMAGENETTE_160\n",
+    "    source = untar_data(path)\n",
+    "    blocks=(ImageBlock, CategoryBlock)\n",
+    "    tfms = [RandomResizedCrop(size, min_scale=0.35), FlipItem(0.5)]\n",
+    "    batch_tfms = [Normalize.from_stats(*imagenet_stats)]\n",
     "\n",
-    "def record(name, model, acc=None):\n",
-    "    \"Parameters, MACs at 64 px, state_dict size on disk and share of zeros in the convolutions\"\n",
-    "    model.eval()\n",
-    "    macs, params = tp.utils.count_ops_and_params(\n",
-    "        model, torch.randn(1, 3, 64, 64).to(next(model.parameters()).device))\n",
-    "    f = tmp/f\"{name}.pth\"; torch.save(model.state_dict(), f)\n",
-    "    w = [m.weight for m in model.modules() if isinstance(m, nn.Conv2d)]\n",
-    "    zeros = sum(int((x == 0).sum()) for x in w) / sum(x.numel() for x in w)\n",
-    "    stages.append(dict(stage=name, params=params, macs=macs, mb=f.stat().st_size/1e6,\n",
-    "                       zeros=zeros, acc=acc))\n",
-    "    print(f\"{name}: {params/1e6:.2f} M parameters, {macs/1e6:.0f} MMACs, \"\n",
-    "          f\"{f.stat().st_size/1e6:.1f} MB state_dict, {zeros:.1%} zeros in conv weights\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "wk008",
-   "metadata": {},
-   "source": [
-    "A ResNet-18 with its ImageNet weights, fine-tuned for three epochs:"
+    "    csv_file = 'noisy_imagenette.csv'\n",
+    "    inp = pd.read_csv(source/csv_file)\n",
+    "    dblock = DataBlock(blocks=blocks,\n",
+    "               splitter=ColSplitter(),\n",
+    "               get_x=ColReader('path', pref=source),\n",
+    "               get_y=ColReader(f'noisy_labels_0'),\n",
+    "               item_tfms=tfms,\n",
+    "               batch_tfms=batch_tfms)\n",
+    "\n",
+    "    return dblock.dataloaders(inp, path=source, bs=bs)\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wk009",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<style>\n",
-       "    /* Turns off some styling */\n",
-       "    progress {\n",
-       "        /* gets rid of default border in Firefox and Opera. */\n",
-       "        border: none;\n",
-       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
-       "        background-size: auto;\n",
-       "    }\n",
-       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
-       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
-       "    }\n",
-       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
-       "        background: #F44336;\n",
-       "    }\n",
-       "</style>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: left;\">\n",
-       "      <th>epoch</th>\n",
-       "      <th>train_loss</th>\n",
-       "      <th>valid_loss</th>\n",
-       "      <th>accuracy</th>\n",
-       "      <th>time</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>0</td>\n",
-       "      <td>0.647689</td>\n",
-       "      <td>0.335134</td>\n",
-       "      <td>0.858593</td>\n",
-       "      <td>00:04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>1</td>\n",
-       "      <td>0.336341</td>\n",
-       "      <td>0.254721</td>\n",
-       "      <td>0.893099</td>\n",
-       "      <td>00:04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>2</td>\n",
-       "      <td>0.187006</td>\n",
-       "      <td>0.204517</td>\n",
-       "      <td>0.922192</td>\n",
-       "      <td>00:04</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "learn = vision_learner(dls, resnet18, metrics=accuracy, concat_pool=False)\n",
-    "learn.unfreeze()\n",
-    "learn.fit_one_cycle(3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "wk010",
+   "id": "a1f4b72982cd",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "baseline: 92.22% (1363/1478), Wilson 95% [90.74%, 93.48%]\n",
-      "baseline: 11.44 M parameters, 149 MMACs, 45.9 MB state_dict, 0.0% zeros in conv weights\n"
+      "9469 training images, 3925 validation images, 10 classes, at 128 pixels\n"
      ]
     }
    ],
    "source": [
-    "record(\"baseline\", learn.model, report(learn, \"baseline\"))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "wk011",
-   "metadata": {},
-   "source": [
-    "`concat_pool=False` gives the head a plain average pool: the exporter of step 5 has no translation\n",
-    "for adaptive max pooling."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "wk012",
-   "metadata": {},
-   "source": [
-    "## 2. Sparsify\n",
-    "\n",
-    "`SparsifyCallback` zeroes weights while training continues:\n",
-    "\n",
-    "- **`sparsity=0.5`** - the fraction of weights to zero\n",
-    "- **`granularity='weight'`** - individual weights, the model keeps its shape\n",
-    "- **`context='local'`** - each layer on its own\n",
-    "- **`criteria=large_final`** - keep the largest final magnitudes\n",
-    "- **`schedule=one_cycle`** - how the sparsity grows to its target"
+    "size, bs = 128, 32\n",
+    "dls = get_dls(size, bs)\n",
+    "print(f'{len(dls.train_ds)} training images, {len(dls.valid_ds)} validation images, '\n",
+    "      f'{len(dls.vocab)} classes, at {size} pixels')\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wk013",
+   "id": "68dd34fb600d",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sparsifying weight until a sparsity of 50.00%\n",
-      "Saving Weights at epoch 0\n"
+      "torch 2.9.1+cu128 | 24 CPU threads | training on cuda:0\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<style>\n",
-       "    /* Turns off some styling */\n",
-       "    progress {\n",
-       "        /* gets rid of default border in Firefox and Opera. */\n",
-       "        border: none;\n",
-       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
-       "        background-size: auto;\n",
-       "    }\n",
-       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
-       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
-       "    }\n",
-       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
-       "        background: #F44336;\n",
-       "    }\n",
-       "</style>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: left;\">\n",
-       "      <th>epoch</th>\n",
-       "      <th>train_loss</th>\n",
-       "      <th>valid_loss</th>\n",
-       "      <th>accuracy</th>\n",
-       "      <th>time</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>0</td>\n",
-       "      <td>0.179395</td>\n",
-       "      <td>0.468179</td>\n",
-       "      <td>0.849120</td>\n",
-       "      <td>00:07</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>1</td>\n",
-       "      <td>0.280292</td>\n",
-       "      <td>0.729538</td>\n",
-       "      <td>0.772666</td>\n",
-       "      <td>00:07</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>2</td>\n",
-       "      <td>0.214267</td>\n",
-       "      <td>0.196754</td>\n",
-       "      <td>0.918809</td>\n",
-       "      <td>00:08</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>3</td>\n",
-       "      <td>0.123649</td>\n",
-       "      <td>0.170752</td>\n",
-       "      <td>0.934371</td>\n",
-       "      <td>00:06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>4</td>\n",
-       "      <td>0.073424</td>\n",
-       "      <td>0.160134</td>\n",
-       "      <td>0.938430</td>\n",
-       "      <td>00:07</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
+    }
+   ],
+   "source": [
+    "print(f'torch {torch.__version__} | {torch.get_num_threads()} CPU threads | '\n",
+    "      f'training on {default_device()}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "867254b9f5c3",
+   "metadata": {},
+   "source": [
+    "Let's start with a bit of context for the purpose of the demonstration. Imagine that we want to deploy a **VGG16** model on a mobile device that has limited storage capacity and that our task requires our model to run sufficiently fast. It is known that parameters and speed efficiency are not the strong points of **VGG16** but let's see what we can do with it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4378943d605a",
+   "metadata": {},
+   "source": [
+    "Let's first check the number of parameters and the inference time of **VGG16**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2544d2c9cf75",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "set_seed(42, reproducible=True)\n",
+    "learn = Learner(dls, models.vgg16_bn(num_classes=10), metrics=[accuracy])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c6369b70461",
+   "metadata": {},
+   "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sparsity at the end of epoch 0: 1.96%\n"
+      "Model Size: 537.30 MB (disk), 134318423 parameters\n"
      ]
-    },
+    }
+   ],
+   "source": [
+    "baseline_params = get_num_parameters(learn.model)\n",
+    "baseline_size = get_model_size(learn.model)\n",
+    "print(f\"Model Size: {baseline_size / 1e6:.2f} MB (disk), {baseline_params} parameters\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "511ea34fe5cf",
+   "metadata": {},
+   "source": [
+    "So our model has **134 millions** parameters and needs **537.30MB** of disk space in order to be stored."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "342eddf4cbae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x, y = dls.one_batch()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d87ac2049cba",
+   "metadata": {},
+   "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sparsity at the end of epoch 1: 20.07%\n"
+      "Inference Speed: 23.40ms (23.34–23.52 over three repeats)\n"
      ]
-    },
+    }
+   ],
+   "source": [
+    "baseline_ms, lo, hi = evaluate_cpu_speed(learn.model, x[0][None])\n",
+    "print(f'Inference Speed: {baseline_ms:.2f}ms ({lo:.2f}–{hi:.2f} over three repeats)')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e7d9de611c3",
+   "metadata": {},
+   "source": [
+    "And it takes **23.40ms** to perform inference on a single image."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8bbaae963af4",
+   "metadata": {},
+   "source": [
+    ":::{.callout-note}\n",
+    "\n",
+    "**Measured on** an Intel i9-14900KS, at the thread count and torch version printed above, one image at a time, ten warm-up passes then three timing repeats of fifty passes each, reported as the mean with the min and max of the three. Every latency on this page comes from that same single run, at the 1-minute load averages the recap prints.\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de75d73ea746",
+   "metadata": {},
+   "source": [
+    "Snap ! This is more than we can afford for deployment, ideally we would like our model to take only half of that...but should we give up ? Nope, there are actually a lot of techniques that we can use to help reducing the size and improve the speed of our models! Let's see how to apply them with **FasterAI**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12d13230b538",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4150349a2ea1",
+   "metadata": {},
+   "source": [
+    "We will first train our **VGG16** model to have a **baseline** of what performance we should expect from it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "284189286a62",
+   "metadata": {},
+   "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sparsity at the end of epoch 2: 45.86%\n"
+      "VGG16 accuracy: 3183/3925 (81.10%)\n",
+      "Inference Speed: 23.84ms (23.82–23.87 over three repeats)\n"
      ]
-    },
+    }
+   ],
+   "source": [
+    "set_seed(42, reproducible=True)\n",
+    "with learn.no_bar(), learn.no_logging(): learn.fit_one_cycle(10, 1e-4)\n",
+    "baseline_k, baseline_n = report_accuracy(learn.model, 'VGG16', dls)\n",
+    "trained_ms, lo, hi = evaluate_cpu_speed(learn.model, x[0][None])\n",
+    "print(f'Inference Speed: {trained_ms:.2f}ms ({lo:.2f}–{hi:.2f} over three repeats)')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eecca1c2c48b",
+   "metadata": {},
+   "source": [
+    "Ten epochs from scratch leave it at **81.10%** (3183/3925 correct on the validation set), and the trained model takes **23.84ms** on that same single image. Those are the two numbers every step below is read against."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d04d9db68eb",
+   "metadata": {},
+   "source": [
+    "So we would like our network to have comparable accuracy but fewer parameters and running faster... And the first technique that we will show how to use is called **Knowledge Distillation**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9de1a9a3e2a3",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a641e1486ac",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0733860cfd8f",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79b493ddd1e3",
+   "metadata": {},
+   "source": [
+    "## **Knowledge Distillation**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ae9fe915773",
+   "metadata": {},
+   "source": [
+    "Knowledge distillation is a simple yet very efficient way to train a model. It was introduced in 2006 by [Caruana et al.](https://www.cs.cornell.edu/~caruana/compression.kdd06.pdf). The main idea behind is to use a small model (called the **student**) to approximate the function learned by a larger and high-performing model (called the **teacher**). This can be done by using the large model to pseudo-label the data. This idea has been used very recently to [break the state-of-the-art accuracy on ImageNet](https://arxiv.org/abs/1911.04252).\n",
+    "\n",
+    "When we train our model for classification, we usually use a softmax as last layer. This softmax has the particularity to squish low value logits towards **0**, and the highest logit towards **1**. This has the effect of completely losing all the inter-class information, or what is sometimes called the *dark knowledge*. This is the information that is valuable and that we want to transfer from the teacher to the student.\n",
+    "\n",
+    "To do so, we still use a regular classification loss but at the same time, we'll use another loss, computed between the *softened* logits of the teacher (our *soft labels*) and the *softened* logits of the student (our *soft predictions*). Those soft values are obtained when you use a **soft-softmax**, that avoids squishing the values at its output. Our implementation follows [this paper](http://cs230.stanford.edu/files_winter_2018/projects/6940224.pdf) and the basic principle of training is represented in the figure below:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19647196f313",
+   "metadata": {},
+   "source": [
+    "<br>\n",
+    "\n",
+    "![](../imgs/distill.png)\n",
+    "\n",
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "028877ea3a5b",
+   "metadata": {},
+   "source": [
+    "To use **Knowledge Distillation** with FasterAI, you only need to use this callback when training your student model:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2f86893dc5b",
+   "metadata": {},
+   "source": [
+    "<br>\n",
+    "\n",
+    "<blockquote>\n",
+    "<pre><b><i> KnowledgeDistillationCallback(teacher, loss) </i></b></pre>\n",
+    "<p style=\"font-size: 15px\"><i>\n",
+    "You only need to give to the callback the model of your teacher and the distillation loss to use. Behind the scenes, FasterAI will take care of making your model train using knowledge distillation.\n",
+    "</i></p>\n",
+    "</blockquote>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac6f3b53605f",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4876858f9346",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fasterai.distill.all import *\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff20b4e4773c",
+   "metadata": {},
+   "source": [
+    "The first thing to do is to find a teacher, which can be any model, that preferrably performs well. We will chose **VGG19** for our demonstration. To make sure it performs better than our **VGG16** model, let's start from a pretrained version."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5cf8c5b93d5e",
+   "metadata": {},
+   "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sparsity at the end of epoch 3: 49.74%\n"
+      "VGG19 teacher accuracy: 3672/3925 (93.55%)\n"
      ]
-    },
+    }
+   ],
+   "source": [
+    "teacher = vision_learner(dls, models.vgg19_bn, metrics=[accuracy])\n",
+    "with teacher.no_bar(), teacher.no_logging(): teacher.fit_one_cycle(3, 1e-4)\n",
+    "teacher_k, teacher_n = report_accuracy(teacher.model, 'VGG19 teacher', dls)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "efb0796c1c91",
+   "metadata": {},
+   "source": [
+    "Our teacher has **93.55%** of accuracy (3672/3925) which is pretty good, it is ready to take a student under its wing. So let's create our student model and train it with the **Knowledge Distillation** callback:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77ea371bc8c4",
+   "metadata": {},
+   "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sparsity at the end of epoch 4: 50.00%\n",
+      "VGG16 student accuracy: 3200/3925 (81.53%)\n",
+      "Difference with the vanilla VGG16: 17 images\n"
+     ]
+    }
+   ],
+   "source": [
+    "set_seed(42, reproducible=True)\n",
+    "student = Learner(dls, models.vgg16_bn(num_classes=10), metrics=[accuracy])\n",
+    "kd_cb = KnowledgeDistillationCallback(teacher.model, SoftTarget)\n",
+    "\n",
+    "set_seed(42, reproducible=True)\n",
+    "with student.no_bar(), student.no_logging(): student.fit_one_cycle(10, 1e-4, cbs=kd_cb)\n",
+    "student_k, student_n = report_accuracy(student.model, 'VGG16 student', dls)\n",
+    "print(f'Difference with the vanilla VGG16: {student_k - baseline_k} images')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d6097d9a356",
+   "metadata": {},
+   "source": [
+    "With the teacher, the student ends at **81.53%** (3200/3925) against **81.10%** (3183/3925) for the vanilla **VGG16** — same ten epochs, same learning rate, same seed, one run each. That is 17 images. One run of each does not say whether that gap survives another seed, so this page does not attribute it to the distillation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "406e3b83ebe4",
+   "metadata": {},
+   "source": [
+    "With some experimentations we could come up with a model smaller than **VGG16** but able to reach the same performance as our baseline! You can try to find it by yourself later, but for now let's continue with the next technique !"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2f09135ef6c",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20b535387454",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0289cc895f2",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abf1347fc164",
+   "metadata": {},
+   "source": [
+    "## **Sparsifying**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a5bdca672ba",
+   "metadata": {},
+   "source": [
+    "Now that we have a student model in hand, we have some room to compress it. And we'll start by making the network sparse. As explained in a previous [article](https://nathanhubens.github.io/posts/deep%20learning/2020/05/22/pruning.html), there are many ways leading to a sparse network."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d46d2cd232a",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4122c5dae9d3",
+   "metadata": {},
+   "source": [
+    ":::{.callout-note}\n",
+    "\n",
+    "Usually, the process of making a network sparse is called Pruning. I prefer using the term Pruning when parameters are **actually** removed from the network, which we will do in the next section.\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b1eac439dab",
+   "metadata": {},
+   "source": [
+    "<br>\n",
+    "\n",
+    "![](../imgs/schedules.png)\n",
+    "\n",
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afde8c3e8c9f",
+   "metadata": {},
+   "source": [
+    "In FasterAI, the sparsification is managed by a callback, that will replace the *least important* parameters of your model by zeroes during the training, following the schedule you hand it — the **Automated Gradual Pruning** of the figure above is one of those, and it removes parameters as the model trains, so it doesn't require to pretrain the model. The callback has a wide variety of parameters to tune your **Sparsifying** operation, let's take a look at them:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "163ddaf7095d",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e89b8dd8ad76",
+   "metadata": {},
+   "source": [
+    "<blockquote>\n",
+    "    <pre><b><i>SparsifyCallback(sparsity, granularity, context, criteria, schedule)</i></b></pre>\n",
+    "\n",
+    "<ul><i>\n",
+    "<li style=\"font-size:15px\"><b>sparsity</b>: the amount of sparsity that you want in your network, as a fraction in [0, 1] (0.5 = 50%)</li>\n",
+    "<li style=\"font-size:15px\"><b>granularity</b>: on what granularity you want the sparsification to be operated</li>\n",
+    "<li style=\"font-size:15px\"><b>context</b>: either <code>local</code> or <code>global</code>, will affect the selection of parameters to be choosen in each layer independently (<code>local</code>) or on the whole network (<code>global</code>).</li>\n",
+    "<li style=\"font-size:15px\"><b>criteria</b>: the criteria used to select which parameters to remove, from <code>fasterai.core.criteria</code> (<code>large_final</code>, <code>movement</code>, <code>random</code>, ...)</li>\n",
+    "<li style=\"font-size:15px\"><b>schedule</b>: which schedule you want to follow for the sparsification, from <code>fasterai.core.schedule</code> (<code>one_shot</code>, <code>iterative</code>, <code>agp</code>, <code>one_cycle</code>, <code>cos</code>, <code>lin</code>)</li>\n",
+    "</i></ul>\n",
+    "</blockquote>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3facd4cfd34e",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea1665e82791",
+   "metadata": {},
+   "source": [
+    "**But let's come back to our example!**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a784d62c6c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| include: false\n",
+    "from fasterai.sparse.all import *\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b3e98680473",
+   "metadata": {},
+   "source": [
+    "Here, we will make our network **50%** sparse, and remove entire **filters**, selected **globally** and based on their **final magnitude**. We will train with a learning rate a bit smaller to be gentle with our network because it has already been trained. The **scheduling** selected is cosinusoidal, so the sparsification starts and ends quite slowly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8246a27c5397",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sparsifying filter until a sparsity of 50.00%\n",
+      "Saving Weights at epoch 0\n",
+      "Sparsity at the end of epoch 0: 1.22%\n",
+      "Sparsity at the end of epoch 1: 4.77%\n",
+      "Sparsity at the end of epoch 2: 10.31%\n",
+      "Sparsity at the end of epoch 3: 17.27%\n",
+      "Sparsity at the end of epoch 4: 25.00%\n",
+      "Sparsity at the end of epoch 5: 32.73%\n",
+      "Sparsity at the end of epoch 6: 39.69%\n",
+      "Sparsity at the end of epoch 7: 45.23%\n",
+      "Sparsity at the end of epoch 8: 48.78%\n",
+      "Sparsity at the end of epoch 9: 50.00%\n",
       "Final Sparsity: 50.00%\n",
       "\n",
       "Sparsity Report:\n",
       "--------------------------------------------------------------------------------\n",
       "Layer                          Type            Params     Zeros      Sparsity  \n",
       "--------------------------------------------------------------------------------\n",
-      "0.0                            Conv2d          9,408      4,702         49.98%\n",
-      "0.4.0.conv1                    Conv2d          36,864     18,430        49.99%\n",
-      "0.4.0.conv2                    Conv2d          36,864     18,430        49.99%\n",
-      "0.4.1.conv1                    Conv2d          36,864     18,430        49.99%\n",
-      "0.4.1.conv2                    Conv2d          36,864     18,430        49.99%\n",
-      "0.5.0.conv1                    Conv2d          73,728     36,862        50.00%\n",
-      "0.5.0.conv2                    Conv2d          147,456    73,726        50.00%\n",
-      "0.5.0.downsample.0             Conv2d          8,192      4,094         49.98%\n",
-      "0.5.1.conv1                    Conv2d          147,456    73,726        50.00%\n",
-      "0.5.1.conv2                    Conv2d          147,456    73,726        50.00%\n",
-      "0.6.0.conv1                    Conv2d          294,912    147,453       50.00%\n",
-      "0.6.0.conv2                    Conv2d          589,824    294,908       50.00%\n",
-      "0.6.0.downsample.0             Conv2d          32,768     16,382        49.99%\n",
-      "0.6.1.conv1                    Conv2d          589,824    294,908       50.00%\n",
-      "0.6.1.conv2                    Conv2d          589,824    294,908       50.00%\n",
-      "0.7.0.conv1                    Conv2d          1,179,648  589,817       50.00%\n",
-      "0.7.0.conv2                    Conv2d          2,359,296  1,179,635     50.00%\n",
-      "0.7.0.downsample.0             Conv2d          131,072    65,534        50.00%\n",
-      "0.7.1.conv1                    Conv2d          2,359,296  1,179,635     50.00%\n",
-      "0.7.1.conv2                    Conv2d          2,359,296  1,179,635     50.00%\n",
+      "features.0                     Conv2d          1,728      0              0.00%\n",
+      "features.3                     Conv2d          36,864     0              0.00%\n",
+      "features.7                     Conv2d          73,728     0              0.00%\n",
+      "features.10                    Conv2d          147,456    0              0.00%\n",
+      "features.14                    Conv2d          294,912    0              0.00%\n",
+      "features.17                    Conv2d          589,824    0              0.00%\n",
+      "features.20                    Conv2d          589,824    0              0.00%\n",
+      "features.24                    Conv2d          1,179,648  783,360       66.41%\n",
+      "features.27                    Conv2d          2,359,296  1,723,392     73.05%\n",
+      "features.30                    Conv2d          2,359,296  1,681,920     71.29%\n",
+      "features.34                    Conv2d          2,359,296  1,626,624     68.95%\n",
+      "features.37                    Conv2d          2,359,296  1,608,192     68.16%\n",
+      "features.40                    Conv2d          2,359,296  1,520,640     64.45%\n",
       "--------------------------------------------------------------------------------\n",
-      "Overall                        all             11,166,912 5,583,371     50.00%\n"
+      "Overall                        all             14,710,464 8,944,128     60.80%\n",
+      "VGG16 sparsified accuracy: 3154/3925 (80.36%)\n"
      ]
     }
    ],
    "source": [
-    "sp_cb = SparsifyCallback(sparsity=0.5, granularity='weight', context='local',\n",
-    "                         criteria=large_final, schedule=one_cycle)\n",
-    "learn.fit_one_cycle(5, cbs=sp_cb)"
+    "sp_cb = SparsifyCallback(sparsity=0.5, granularity='filter', context='global',\n",
+    "                         criteria=large_final, schedule=cos)\n",
+    "with student.no_bar(), student.no_logging(): student.fit(10, 1e-5, cbs=sp_cb)\n",
+    "sparse_k, sparse_n = report_accuracy(student.model, 'VGG16 sparsified', dls)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b0e7dd131d4",
+   "metadata": {},
+   "source": [
+    "Our network now has **50%** of its filters composed entirely of zeroes, and it ends at **80.36%** (3154/3925) against **81.53%** (3200/3925) before the sparsification — one run each. Read the report above rather than that single figure: the sparsity is spread very unevenly, because a **global** context compares the filters of the whole network against each other, and here the first seven convolutions kept all of theirs. Obviously, choosing a higher sparsity makes it more difficult for the network to keep a similar accuracy. Other parameters can also widely change the behaviour of our sparsification process. For example choosing a more fine-grained sparsity picks the weights one by one instead of by whole filters, which is then more difficult to take advantage of in terms of speed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e62f9bd7e446",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e03b2a45621",
+   "metadata": {},
+   "source": [
+    "Let's now see how much we gained in terms of speed. Because we removed **50%** of convolution filters, we should expect crazy speed-up right ?"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wk014",
+   "id": "7d18dcbc15b8",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "sparsified: 93.84% (1387/1478), Wilson 95% [92.50%, 94.96%]\n",
-      "sparsified: 11.44 M parameters, 149 MMACs, 45.9 MB state_dict, 50.0% zeros in conv weights\n"
+      "Inference Speed: 24.56ms (24.54–24.58 over three repeats)\n"
      ]
     }
    ],
    "source": [
-    "record(\"sparsified\", learn.model, report(learn, \"sparsified\"))"
+    "sparse_ms, lo, hi = evaluate_cpu_speed(student.model, x[0][None])\n",
+    "print(f'Inference Speed: {sparse_ms:.2f}ms ({lo:.2f}–{hi:.2f} over three repeats)')\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "wk015",
+   "id": "53b9951c6dc7",
    "metadata": {},
    "source": [
-    "Half of the convolution weights are zero and nothing else moved: same parameter count, same MACs,\n",
-    "same file on disk. A dense format stores a zero like any other number."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "wk016",
-   "metadata": {},
-   "source": [
-    "## 3. Prune\n",
-    "\n",
-    "`Pruner` removes the filters themselves. It runs once, outside the training loop, and the fit that\n",
-    "follows retrains what is left."
+    "Well actually, no: **24.56ms**, against **23.40ms** for the dense model, single run each. We didn't remove any parameters, we just replaced some by zeroes, remember? The amount of parameters is still the same:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wk017",
+   "id": "89ff8c3059b3",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Ignoring output layer: 1.8\n",
-      "Total ignored layers: 1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "pruned: 5.59 M parameters, 74 MMACs, 22.4 MB state_dict, 48.8% zeros in conv weights\n"
+      "Model Size: 537.30 MB (disk), 134318423 parameters\n"
      ]
     }
    ],
    "source": [
-    "pruner = Pruner(learn.model, 0.3, 'local', large_final,\n",
-    "                example_inputs=torch.randn(1, 3, 64, 64).to(default_device()))\n",
-    "pruner.prune_model()\n",
-    "\n",
-    "record(\"pruned\", learn.model)"
+    "sparse_params = get_num_parameters(student.model)\n",
+    "sparse_size = get_model_size(student.model)\n",
+    "print(f\"Model Size: {sparse_size / 1e6:.2f} MB (disk), {sparse_params} parameters\")\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "wk018",
+   "id": "68e7a754bcbc",
    "metadata": {},
    "source": [
-    "Pruning drops the share of zeros a little: `large_final` removes the lowest-magnitude filters, which\n",
-    "hold more than their share of zeros. The recovery fit re-applies `SparsifyCallback`, so the model ends\n",
-    "it at 50 % zeros again — its `one_cycle` schedule ramps the target back up from 0, which is why the\n",
-    "intermediate epochs print less: a fresh mask, not the one from step 2."
+    "Which leads us to the next section."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf14b3a22f10",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e0ef2df3a0f",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a3745083012",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13478ffb9f5a",
+   "metadata": {},
+   "source": [
+    "## **Pruning**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40a74263eef0",
+   "metadata": {},
+   "source": [
+    "Why don't we see any acceleration even though we zeroed half of the filters? That's because natively, our hardware does not know that our matrices are sparse and thus isn't able to accelerate the computation. The easiest work around, is to **physically** remove filters — most of the ones we zeroed, since the pruner selects its own half. But this operation requires to change the architecture of the network.\n",
+    "\n",
+    "This pruning only works if we remove entire filters as it is the only case where we can change the architecture accordingly. Hopefully, sparse computations are [making their way](https://pytorch.org/docs/stable/sparse.html) into common deep learning librairies so this section may become useless in the future.\n",
+    "\n",
+    "<br>\n",
+    "\n",
+    "Here is what it looks like with fasterai:\n",
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe4e65c6840f",
+   "metadata": {},
+   "source": [
+    "![](../imgs/pruning_filters.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e31fe52f776e",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "914fc702c92c",
+   "metadata": {},
+   "source": [
+    "<blockquote>\n",
+    "    <pre><b><i>PruneCallback(pruning_ratio, schedule, context, criteria)</i></b></pre>\n",
+    "\n",
+    "<ul><i>\n",
+    "<li style=\"font-size:15px\"><b>pruning_ratio</b>: the amount of filters to remove, as a fraction in [0, 1] (0.5 = 50%)</li>\n",
+    "<li style=\"font-size:15px\"><b>schedule</b>: which schedule you want to follow for the pruning, from <code>fasterai.core.schedule</code></li>\n",
+    "<li style=\"font-size:15px\"><b>context</b>: either <code>local</code> or <code>global</code>, will affect the selection of filters to be choosen in each layer independently (<code>local</code>) or on the whole network (<code>global</code>).</li>\n",
+    "<li style=\"font-size:15px\"><b>criteria</b>: the criteria used to select which filters to remove, from <code>fasterai.core.criteria</code></li>\n",
+    "</i></ul>\n",
+    "</blockquote>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a464e59467f2",
+   "metadata": {},
+   "source": [
+    "So in the case of our example, it gives:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wk019",
+   "id": "4b1cdd8bed83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fasterai.prune.all import *\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac6dd5a1b3ea",
+   "metadata": {},
+   "source": [
+    "Let's now see what our model is capable of now:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c40e40177a0b",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sparsifying weight until a sparsity of 50.00%\n",
-      "Saving Weights at epoch 0\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<style>\n",
-       "    /* Turns off some styling */\n",
-       "    progress {\n",
-       "        /* gets rid of default border in Firefox and Opera. */\n",
-       "        border: none;\n",
-       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
-       "        background-size: auto;\n",
-       "    }\n",
-       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
-       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
-       "    }\n",
-       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
-       "        background: #F44336;\n",
-       "    }\n",
-       "</style>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: left;\">\n",
-       "      <th>epoch</th>\n",
-       "      <th>train_loss</th>\n",
-       "      <th>valid_loss</th>\n",
-       "      <th>accuracy</th>\n",
-       "      <th>time</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>0</td>\n",
-       "      <td>0.272020</td>\n",
-       "      <td>1.469996</td>\n",
-       "      <td>0.773342</td>\n",
-       "      <td>00:05</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>1</td>\n",
-       "      <td>0.188387</td>\n",
-       "      <td>0.222212</td>\n",
-       "      <td>0.911367</td>\n",
-       "      <td>00:04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>2</td>\n",
-       "      <td>0.106858</td>\n",
-       "      <td>0.214357</td>\n",
-       "      <td>0.920162</td>\n",
-       "      <td>00:06</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Sparsity at the end of epoch 0: 10.40%\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Sparsity at the end of epoch 1: 48.30%\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Sparsity at the end of epoch 2: 50.00%\n",
-      "Final Sparsity: 50.00%\n",
-      "\n",
-      "Sparsity Report:\n",
-      "--------------------------------------------------------------------------------\n",
-      "Layer                          Type            Params     Zeros      Sparsity  \n",
-      "--------------------------------------------------------------------------------\n",
-      "0.0                            Conv2d          6,468      3,232         49.97%\n",
-      "0.4.0.conv1                    Conv2d          17,424     8,710         49.99%\n",
-      "0.4.0.conv2                    Conv2d          17,424     8,710         49.99%\n",
-      "0.4.1.conv1                    Conv2d          17,424     8,710         49.99%\n",
-      "0.4.1.conv2                    Conv2d          17,424     8,710         49.99%\n",
-      "0.5.0.conv1                    Conv2d          35,244     17,620        49.99%\n",
-      "0.5.0.conv2                    Conv2d          71,289     35,642        50.00%\n",
-      "0.5.0.downsample.0             Conv2d          3,916      1,956         49.95%\n",
-      "0.5.1.conv1                    Conv2d          71,289     35,642        50.00%\n",
-      "0.5.1.conv2                    Conv2d          71,289     35,642        50.00%\n",
-      "0.6.0.conv1                    Conv2d          143,379    71,687        50.00%\n",
-      "0.6.0.conv2                    Conv2d          288,369    144,180       50.00%\n",
-      "0.6.0.downsample.0             Conv2d          15,931     7,964         49.99%\n",
-      "0.6.1.conv1                    Conv2d          288,369    144,180       50.00%\n",
-      "0.6.1.conv2                    Conv2d          288,369    144,180       50.00%\n",
-      "0.7.0.conv1                    Conv2d          576,738    288,362       50.00%\n",
-      "0.7.0.conv2                    Conv2d          1,153,476  576,725       50.00%\n",
-      "0.7.0.downsample.0             Conv2d          64,082     32,039        50.00%\n",
-      "0.7.1.conv1                    Conv2d          1,153,476  576,725       50.00%\n",
-      "0.7.1.conv2                    Conv2d          1,153,476  576,725       50.00%\n",
-      "--------------------------------------------------------------------------------\n",
-      "Overall                        all             5,454,856  2,727,341     50.00%\n"
+      "Ignoring output layer: classifier.6\n",
+      "Total ignored layers: 1\n",
+      "Pruning ratio at the end of epoch 0: 1.94%\n",
+      "Pruning ratio at the end of epoch 1: 19.96%\n",
+      "Pruning ratio at the end of epoch 2: 45.82%\n",
+      "Pruning ratio at the end of epoch 3: 49.74%\n",
+      "Pruning ratio at the end of epoch 4: 50.00%\n",
+      "VGG16 pruned accuracy: 3158/3925 (80.46%)\n"
      ]
     }
    ],
    "source": [
-    "sp_cb = SparsifyCallback(sparsity=0.5, granularity='weight', context='local',\n",
-    "                         criteria=large_final, schedule=one_cycle)\n",
-    "learn.fit_one_cycle(3, reset_opt=True, cbs=sp_cb)"
+    "pr_cb = PruneCallback(pruning_ratio=0.5, schedule=one_cycle, context='global',\n",
+    "                      criteria=large_final)\n",
+    "with student.no_bar(), student.no_logging(): student.fit(5, 1e-5, cbs=pr_cb)\n",
+    "pruned_k, pruned_n = report_accuracy(student.model, 'VGG16 pruned', dls)\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wk020",
+   "id": "e5f75cb8590d",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "pruned + recovery: 92.02% (1360/1478), Wilson 95% [90.52%, 93.29%]\n",
-      "pruned + recovery: 5.59 M parameters, 74 MMACs, 22.4 MB state_dict, 50.0% zeros in conv weights\n"
+      "Model Size: 173.95 MB (disk), 43481770 parameters\n"
      ]
     }
    ],
    "source": [
-    "record(\"pruned + recovery\", learn.model, report(learn, \"pruned + recovery\"))"
+    "pruned_params = get_num_parameters(student.model)\n",
+    "pruned_size = get_model_size(student.model)\n",
+    "print(f\"Model Size: {pruned_size / 1e6:.2f} MB (disk), {pruned_params} parameters\")\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "wk021",
+   "id": "2a7e720dc571",
    "metadata": {},
    "source": [
-    "Removing filters halves the parameter count, the MACs and the `state_dict`, and the model ends the\n",
-    "recovery fit at 50 % zeros again. The accuracy after recovery sits inside the baseline's interval."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "wk022",
-   "metadata": {},
-   "source": [
-    "## 4. Quantize\n",
-    "\n",
-    "`Quantizer(backend='pt2e')` captures the model with `torch.export` and rewrites it to compute in INT8.\n",
-    "Static quantization reads the activation ranges off calibration data, so it needs a loader."
+    "And in terms of speed:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wk023",
+   "id": "ece322e39c47",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'backend': 'pt2e', 'method': 'static', 'weight_bits': 8, 'act_bits': 8, 'qscheme': 'per_channel', 'symmetric': True, 'group_size': None, 'layer_bits': None, 'qdq_placement': 'per_op', 'skip_activations': None, 'engine': None}\n",
-      "W8A8 | exportable: True\n"
+      "Inference Speed: 14.60ms (14.58–14.62 over three repeats)\n"
      ]
     }
    ],
    "source": [
-    "BATCH = 2   # torch.export captures ONE batch size, and 1478 = 739 x 2\n",
-    "\n",
-    "model = learn.model.cpu().eval()\n",
-    "quantizer = Quantizer(backend='pt2e', method='static')\n",
-    "qmodel = quantizer.quantize(model, calibration_dl=dls.train.new(bs=BATCH),\n",
-    "                            max_calibration_samples=64)\n",
-    "\n",
-    "print(quantizer.spec.as_dict())\n",
-    "print(quant_spec(qmodel).label, \"| exportable:\", quant_spec(qmodel).exports)"
+    "pruned_ms, lo, hi = evaluate_cpu_speed(student.model, x[0][None])\n",
+    "print(f'Inference Speed: {pruned_ms:.2f}ms ({lo:.2f}–{hi:.2f} over three repeats)')\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "wk024",
+   "id": "ee0ae3bcc776",
    "metadata": {},
    "source": [
-    "`W8A8` is the resolved precision — 8-bit weights and activations, per-channel scales, a zero-point of\n",
-    "0 everywhere, as `qdq_stats` shows below — and it travels with the model. That graph still stores float\n",
-    "weights and simulates the quantization; the INT8 artifact is the next step's file."
+    "Yay ! Now we can talk ! The filters are gone for real this time — **43481770** parameters left against **134318423** with the same filters merely zeroed, and **14.60ms** against **24.56ms**, single run each. And the accuracy printed above says we didn't mess up somewhere: **80.46%** (3158/3925) at the end of the pruning fit."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "wk025",
+   "id": "aeaefddaa870",
    "metadata": {},
    "source": [
-    "## 5. Export\n",
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d402fae0e6f8",
+   "metadata": {},
+   "source": [
+    "And there is actually more that we can do ! Let's keep going !"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66f5fbe4a3d2",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67e567a5e3df",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e100d252b409",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4c2e7f9ac0a",
+   "metadata": {},
+   "source": [
+    "## **Batch Normalization Folding**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50e3beeb646f",
+   "metadata": {},
+   "source": [
+    "**Batch Normalization Folding** is a really easy to implement and straightforward idea. The gist is that batch normalization is nothing more than a normalization of the input data at each layer. Moreover, at inference time, the batch statistics used for this normalization are fixed. We can thus incorporate the normalization process directly in the convolution by changing its weights and completely remove the batch normalization layers, which is a gain both in terms of parameters and in terms of computations. For a more in-depth explaination, see this [blog post](https://nathanhubens.github.io/posts/deep%20learning/2020/04/20/BN.html).\n",
     "\n",
-    "`export_qdq` writes the quantize/dequantize pairs into the graph instead of folding them away.\n",
-    "`export_onnx` exports the float model, to have something to compare the file against."
+    "This is how to use it with FasterAI:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4814e8464ec0",
+   "metadata": {},
+   "source": [
+    "<blockquote>\n",
+    "<pre><b><i>bn_folder = BN_Folder()\n",
+    "bn_folder.fold(model)</i></b></pre>\n",
+    "<p style=\"font-size: 15px\"><i>\n",
+    "Again, you only need to pass your model and FasterAI takes care of the rest. For models built using the nn.Sequential, you don't need to change anything. For others, if you want to see speedup and compression, you actually need to subclass your model to remove the batch norm from the parameters and from the <code>forward</code> method of your network.\n",
+    "</i></p>\n",
+    "</blockquote>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3dfd49b58993",
+   "metadata": {},
+   "source": [
+    ":::{.callout-note}\n",
+    "\n",
+    "This operation is lossless in exact arithmetic, as it redefines the convolution to take batch norm into account and is thus equivalent. In float32 it left the count of correct predictions where it was, 3158/3925 before and after.\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db628f3e2b8c",
+   "metadata": {},
+   "source": [
+    "<br>"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wk026",
+   "id": "397d163e965b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fasterai.misc.bn_folding import *\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a753c5a6158d",
+   "metadata": {},
+   "source": [
+    "Let's do this with our model !"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a51b0abb54f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bn_f = BN_Folder()\n",
+    "folded_model = bn_f.fold(student.model.eval())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1f1d1bf7ca3",
+   "metadata": {},
+   "source": [
+    "The parameters drop is generally not that significant, especially in a network such as **VGG** where almost all parameters are contained in the FC layers but, hey, any gain is good to take."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b75c19e8b49",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[torch.onnx] Obtain model graph for `GraphModule([...]` with `torch.export.export(..., strict=False)`...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[torch.onnx] Obtain model graph for `GraphModule([...]` with `torch.export.export(..., strict=False)`... ✅\n",
-      "[torch.onnx] Run decomposition...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[torch.onnx] Run decomposition... ✅\n",
-      "[torch.onnx] Translate the graph into ONNX...\n",
-      "[torch.onnx] Translate the graph into ONNX... ✅\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "pets_fp32.onnx 22.4 MB | pets_qdq.onnx 5.9 MB (3.8x smaller on disk)\n"
+      "Model Size: 173.89 MB (disk), 43470249 parameters\n"
      ]
     }
    ],
    "source": [
-    "sample, _ = dls.valid.new(bs=BATCH).one_batch()\n",
-    "sample = sample.cpu()\n",
-    "\n",
-    "fp32_path = export_onnx(model, sample, tmp/\"pets_fp32.onnx\", dynamic_batch=False)\n",
-    "qdq_path = export_qdq(qmodel, sample, tmp/\"pets_qdq.onnx\")\n",
-    "\n",
-    "fp32_mb, qdq_mb = fp32_path.stat().st_size/1e6, qdq_path.stat().st_size/1e6\n",
-    "print(f\"{fp32_path.name} {fp32_mb:.1f} MB | {qdq_path.name} {qdq_mb:.1f} MB \"\n",
-    "      f\"({fp32_mb/qdq_mb:.1f}x smaller on disk)\")"
+    "folded_params = get_num_parameters(folded_model)\n",
+    "folded_size = get_model_size(folded_model)\n",
+    "print(f\"Model Size: {folded_size / 1e6:.2f} MB (disk), {folded_params} parameters\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c97b8b2ace24",
+   "metadata": {},
+   "source": [
+    "Now that we removed the batch normalization layers, we should again see a speedup."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wk027",
+   "id": "0125ce919d00",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'n_quantize': 36, 'n_dequantize': 58, 'n_per_channel': 22, 'n_nonzero_zero_point': 0, 'n_unquantized_conv_add': 0}\n",
-      "22 weight tensors (convolutions and Linear layers) in the model\n"
+      "Inference Speed: 12.29ms (12.29–12.30 over three repeats)\n"
      ]
     }
    ],
    "source": [
-    "print(qdq_stats(qdq_path).as_dict())\n",
-    "print(sum(1 for m in model.modules() if isinstance(m, (nn.Conv2d, nn.Linear))),\n",
-    "      \"weight tensors (convolutions and Linear layers) in the model\")"
+    "folded_ms, lo, hi = evaluate_cpu_speed(folded_model, x[0][None])\n",
+    "print(f'Inference Speed: {folded_ms:.2f}ms ({lo:.2f}–{hi:.2f} over three repeats)')\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "wk028",
+   "id": "135c813d8afa",
    "metadata": {},
    "source": [
-    "`qdq_stats` counts what the exporter actually wrote:\n",
-    "\n",
-    "- `n_quantize` / `n_dequantize` — the pairs a runtime reads to build its INT8 kernels.\n",
-    "- `n_per_channel` — one node per quantized weight tensor, which is the count printed above.\n",
-    "- `n_nonzero_zero_point` — 0, what a symmetric quantizer promised, read off the file.\n",
-    "- `n_unquantized_conv_add` — 0: every `Add` reads its inputs through a pair."
+    "**12.29ms**, against **14.60ms** before the fold, single run each."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "wk029",
+   "id": "83cd3aa69ab3",
    "metadata": {},
    "source": [
-    "`verify_qdq` reports how often the exported graph and the PyTorch model it came from predict the same\n",
-    "class — worth reading only if the reference predictions vary, so this checks first."
+    "Again, let's double check that we didn't mess up somewhere:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wk030",
+   "id": "3f216a143177",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "reference predictions per class: [182, 74]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "argmax agreement: 1.000 (256/256), Wilson 95% [98.52%, 100.00%]\n"
+      "VGG16 folded accuracy: 3158/3925 (80.46%)\n",
+      "Correct predictions moved by the fold: 0\n"
      ]
     }
    ],
    "source": [
-    "probe, _ = dls.valid.new(bs=256).one_batch()\n",
-    "probe = probe.cpu()\n",
-    "\n",
-    "with torch.no_grad():\n",
-    "    reference = torch.cat([qmodel(c).argmax(-1) for c in probe.split(BATCH)])\n",
-    "assert len(reference.unique()) > 1, \"the reference predicts a single class: agreement would be vacuous\"\n",
-    "print(\"reference predictions per class:\", torch.bincount(reference, minlength=2).tolist())\n",
-    "\n",
-    "agreement = verify_qdq(qmodel, qdq_path, probe, n_batches=len(probe)//BATCH)\n",
-    "k, n, z = round(agreement*len(probe)), len(probe), 1.96\n",
-    "p, d = k/n, 1 + z**2/n\n",
-    "c, h = p + z**2/(2*n), z*sqrt(p*(1-p)/n + z**2/(4*n**2))\n",
-    "print(f\"argmax agreement: {agreement:.3f} ({k}/{n}), Wilson 95% [{(c-h)/d:.2%}, {(c+h)/d:.2%}]\")"
+    "folded_learner = Learner(dls, folded_model, metrics=[accuracy])\n",
+    "folded_k, folded_n = report_accuracy(folded_learner.model, 'VGG16 folded', dls)\n",
+    "print(f'Correct predictions moved by the fold: {folded_k - pruned_k}')\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "wk031",
+   "id": "583e66838f4a",
    "metadata": {},
    "source": [
-    "The reference predicts both classes, so the comparison is not vacuous, and the graph answers the same\n",
-    "class on every probe input. This is agreement with the quantized PyTorch model, not accuracy: it says\n",
-    "the file runs at the batch size it was captured with and computes what its source graph computes."
+    "And we're still not done yet ! As we know for **VGG16**, most of the parameters are comprised in the fully-connected layers so there should be something that we can do about it, right ?"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "wk032",
+   "id": "f1260e4d94b6",
    "metadata": {},
    "source": [
-    "Agreement is not accuracy: the last cell scores the exported file over the whole validation set\n",
-    "through `ONNXModel` (onnxruntime behind a PyTorch-like call)."
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2188a4e1835e",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9582ea45018d",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fae41a9d5a6",
+   "metadata": {},
+   "source": [
+    "## **FC Layers Factorization**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21e6d2e8be4e",
+   "metadata": {},
+   "source": [
+    "We can indeed, factorize our big fully-connected layers and replace them by an approximation of two smaller layers. The idea is to make an **SVD** decomposition of the weight matrix, which will express the original matrix in a product of 3 matrices: $U \\Sigma V^T$. With $\\Sigma$ being a diagonal matrix with non-negative values along its diagonal (the singular values). We then define a value $k$ of singular values to keep and modify matrices $U$ and $V^T$ accordingly. The resulting will be an approximation of the initial matrix."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23b743d79eab",
+   "metadata": {},
+   "source": [
+    "![](../imgs/svd.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b8f1ddee51d",
+   "metadata": {},
+   "source": [
+    "In FasterAI, to decompose the fully-connected layers of your model, here is what you need to do:\n",
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bc28b8c2b72",
+   "metadata": {},
+   "source": [
+    "<blockquote>\n",
+    "<pre><b><i>FCD = FC_Decomposer()\n",
+    "decomposed_model = FCD.decompose(model, percent_removed)</i></b></pre>\n",
+    "<p style=\"font-size: 15px\"><i>\n",
+    "    The <code>percent_removed</code> corresponds to the fraction of singular values removed (the <i>k</i> value above).\n",
+    "</i></p>\n",
+    "</blockquote>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07271a0e22a0",
+   "metadata": {},
+   "source": [
+    ":::{.callout-note}\n",
+    "\n",
+    "This time, the decomposition is not exact, so we expect a drop in performance afterwards and further retraining will be needed.\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd001aca8049",
+   "metadata": {},
+   "source": [
+    "Which gives with our example, if we only want to keep half of them:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wk033",
+   "id": "002555f3bef8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fasterai.misc.fc_decomposer import *\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a922a5698fac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fc_decomposer = FC_Decomposer()\n",
+    "decomposed_model = fc_decomposer.decompose(folded_learner.model, percent_removed=0.5)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f22e946d574a",
+   "metadata": {},
+   "source": [
+    "How many parameters do we have now ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26f9bd5e3e3e",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "exported INT8 graph: 91.95% (1359/1478), Wilson 95% [90.45%, 93.23%]\n"
+      "Model Size: 104.98 MB (disk), 26243247 parameters\n"
      ]
     }
    ],
    "source": [
-    "onnx_model = ONNXModel(qdq_path)\n",
-    "\n",
-    "k = n = 0\n",
-    "for x, y in dls.valid.new(bs=BATCH):\n",
-    "    k += int((onnx_model(x.cpu()).argmax(-1) == y.cpu()).sum()); n += len(y)\n",
-    "z = 1.96; p, d = k/n, 1 + z**2/n\n",
-    "c, h = p + z**2/(2*n), z*sqrt(p*(1-p)/n + z**2/(4*n**2))\n",
-    "print(f\"exported INT8 graph: {k/n:.2%} ({k}/{n}), Wilson 95% [{(c-h)/d:.2%}, {(c+h)/d:.2%}]\")"
+    "decomposed_params = get_num_parameters(decomposed_model)\n",
+    "decomposed_size = get_model_size(decomposed_model)\n",
+    "print(f\"Model Size: {decomposed_size / 1e6:.2f} MB (disk), {decomposed_params} parameters\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa6ef3d444bd",
+   "metadata": {},
+   "source": [
+    "And how much time did we gain ?"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "wk034",
+   "id": "c94c64d48d0f",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "stage                   params   MMACs  conv zeros  state_dict   accuracy\n",
-      "baseline                11.44M     149        0.0%       45.9M     92.22%\n",
-      "sparsified              11.44M     149       50.0%       45.9M     93.84%\n",
-      "pruned                   5.59M      74       48.8%       22.4M          -\n",
-      "pruned + recovery        5.59M      74       50.0%       22.4M     92.02%\n",
-      "MMACs: multiply-accumulates for one 64x64 image | conv zeros: share of zeros in the convolution weights\n",
-      "\n",
-      "ONNX files: FP32 22.4 MB | QDQ INT8 5.9 MB, which scored 91.95% (1359/1478) on the validation set\n"
+      "Inference Speed: 10.93ms (10.91–10.96 over three repeats)\n"
      ]
     }
    ],
    "source": [
-    "print(f\"{'stage':<20}{'params':>10}{'MMACs':>8}{'conv zeros':>12}{'state_dict':>12}{'accuracy':>11}\")\n",
-    "for s in stages:\n",
-    "    acc = f\"{s['acc']:.2%}\" if s['acc'] is not None else \"-\"\n",
-    "    print(f\"{s['stage']:<20}{s['params']/1e6:>9.2f}M{s['macs']/1e6:>8.0f}\"\n",
-    "          f\"{s['zeros']:>12.1%}{s['mb']:>11.1f}M{acc:>11}\")\n",
-    "print(\"MMACs: multiply-accumulates for one 64x64 image | conv zeros: share of zeros in the \"\n",
-    "      \"convolution weights\")\n",
-    "print(f\"\\nONNX files: FP32 {fp32_mb:.1f} MB | QDQ INT8 {qdq_mb:.1f} MB, \"\n",
-    "      f\"which scored {k/n:.2%} ({k}/{n}) on the validation set\")"
+    "decomposed_ms, lo, hi = evaluate_cpu_speed(decomposed_model, x[0][None])\n",
+    "print(f'Inference Speed: {decomposed_ms:.2f}ms ({lo:.2f}–{hi:.2f} over three repeats)')\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "wk035",
+   "id": "001e0859bcfa",
    "metadata": {},
    "source": [
-    "The four accuracies of this run are successive stages of one model, not the arms of an A/B — each row\n",
-    "carries a different training budget — and their Wilson intervals overlap, so this page ranks none of\n",
-    "them.\n",
-    "\n",
-    "**Scope.** ResNet-18 with ImageNet weights, PETS cat/dog labels, 64 px: three epochs of fine-tuning,\n",
-    "five with `SparsifyCallback`, one `Pruner` step, three recovery epochs, calibration on 64 training\n",
-    "images. Single run, no seed fixed; device and library versions printed at the top, the ONNX graphs\n",
-    "scored on CPU through onnxruntime. Accuracy is measured on the 1478 validation images with its Wilson\n",
-    "95% interval. This page measures no latency."
+    "The parameters go from **43470249** down to **26243247**, and the timing from **12.29ms** to **10.93ms**, single run each. This is thus a matter of compromise between network weight and speed, and here both went the same way."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "wk036",
+   "id": "0c857b085125",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b994ca5df237",
+   "metadata": {},
+   "source": [
+    "However, this technique is an approximation so it is not lossless, so we should retrain our network a bit to recover its performance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57b431fa06a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "VGG16 decomposed accuracy: 3060/3925 (77.96%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "final_learner = Learner(dls, decomposed_model, metrics=[accuracy])\n",
+    "with final_learner.no_bar(), final_learner.no_logging(): final_learner.fit_one_cycle(5, 1e-5)\n",
+    "decomposed_k, decomposed_n = report_accuracy(final_learner.model, 'VGG16 decomposed', dls)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a52b0aa755f7",
+   "metadata": {},
+   "source": [
+    "This operation reaches whatever a network keeps in its fully-connected layers, and more recent architectures usually do not keep that many parameters there."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8698f59179bb",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "181ebf3abe5a",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb04c2907692",
+   "metadata": {},
+   "source": [
+    "## Quantization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01ed11d1f410",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fasterai.quantize.all import *\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5c75698a957",
+   "metadata": {},
+   "source": [
+    "Now that we have removed every superfluous parameter that we could, we can still continue to compress our model. A common way to do so is now to reduce the precision of each parameter in the network, making it considerably smaller. Such an approach is called **Quantization** and won't affect the total number of parameter but will make each one of them smaller to store, and have the network compute in 8-bit integers instead of floats."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1563abe9d9c1",
+   "metadata": {},
+   "source": [
+    "In **FasterAI**, quantization can be done in a static way, i.e. apply quantization to the model, also called Post-Training Quantization. It also can be applied during training, also called Quantization-Aware Training. The callback below does the second one: it swaps the layers for their observed counterparts before the fit, trains through them, and converts the result to an actual 8-bit model afterwards."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae8f7dc9eea0",
+   "metadata": {},
+   "source": [
+    "<blockquote>\n",
+    "<pre><b><i>QuantizeCallback(backend='x86')</i></b></pre>\n",
+    "<p style=\"font-size: 15px\"><i>\n",
+    "    The <code>backend</code> is the engine the quantized model will run on; <code>x86</code> is the CPU one, and the model that comes out of the fit runs on the CPU, which is where we measure it.\n",
+    "</i></p>\n",
+    "</blockquote>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ab28c918f46",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "VGG16 quantized accuracy: 3125/3925 (79.62%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "with final_learner.no_bar(), final_learner.no_logging():\n",
+    "    final_learner.fit_one_cycle(5, 1e-5, cbs=QuantizeCallback())\n",
+    "quantized_k, quantized_n = report_accuracy(final_learner.model, 'VGG16 quantized', dls)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cf9fe9cbc67",
+   "metadata": {},
+   "source": [
+    "The model that comes out of the fit is an 8-bit one, and it scores **79.62%** (3125/3925) after five more epochs, against **77.96%** (3060/3925) for the floating-point model those epochs started from — one run each, two things changed at once."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a5ac5982f3c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model Size: 26.42 MB (disk), 26243287 parameters\n"
+     ]
+    }
+   ],
+   "source": [
+    "quantized_params = get_num_parameters(final_learner.model)\n",
+    "quantized_size = get_model_size(final_learner.model)\n",
+    "print(f\"Model Size: {quantized_size / 1e6:.2f} MB (disk), {quantized_params} parameters\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "557208e7deac",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Inference Speed: 7.99ms (7.33–9.29 over three repeats)\n"
+     ]
+    }
+   ],
+   "source": [
+    "quantized_ms, lo, hi = evaluate_cpu_speed(final_learner.model, x[0][None])\n",
+    "print(f'Inference Speed: {quantized_ms:.2f}ms ({lo:.2f}–{hi:.2f} over three repeats)')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b61d0fb11bf9",
+   "metadata": {},
+   "source": [
+    "The count barely moves — **26243287** against **26243247**, the few extra ones being the scales the quantized layers carry — but each parameter is now stored on 8 bits instead of 32, so the model takes **26.42 MB** against **104.98 MB**. And it runs in **7.99ms** against **10.93ms** for the floating-point model it was converted from, single run each."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af318f808d76",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e88acb9f1f9",
+   "metadata": {},
+   "source": [
+    "## Extra Acceleration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba633a9a9724",
+   "metadata": {},
+   "source": [
+    "One last thing, which compresses nothing but takes what we have and hands it to the CPU in the shape it likes: a channels-last memory layout and a traced graph, so the Python overhead of the module tree is gone at inference time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86095cfa7864",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fasterai.misc.cpu_optimizer import optimize_for_cpu\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68c322b05670",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "final_model = optimize_for_cpu(final_learner.model, x[0][None].cpu(), backend='trace')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f99649831fda",
+   "metadata": {},
+   "source": [
+    "A traced object carries its own code along with its weights, so what it writes to disk is not quite the state dict of the model it came from:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4c612d4f4f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model Size: 26.52 MB (disk)\n"
+     ]
+    }
+   ],
+   "source": [
+    "accelerated_size = get_model_size(final_model)\n",
+    "print(f\"Model Size: {accelerated_size / 1e6:.2f} MB (disk)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cb225d47e14",
+   "metadata": {},
+   "source": [
+    "**26.52 MB**, against **26.42 MB** for the state dict of the same model. And in terms of speed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b7d9b2ffdb9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Inference Speed: 6.38ms (6.36–6.41 over three repeats)\n"
+     ]
+    }
+   ],
+   "source": [
+    "accelerated_ms, lo, hi = evaluate_cpu_speed(final_model, x[0][None])\n",
+    "print(f'Inference Speed: {accelerated_ms:.2f}ms ({lo:.2f}–{hi:.2f} over three repeats)')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b21c93a2dee5",
+   "metadata": {},
+   "source": [
+    "**6.38ms**, against **7.99ms** for the same weights run eagerly in the default memory layout, single run each."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14e51aa4034f",
+   "metadata": {},
+   "source": [
+    "Again, let's double check that we didn't mess up somewhere:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e18aa8c514b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "VGG16 traced accuracy: 3125/3925 (79.62%)\n",
+      "predictions identical on 3925 of 3925 images\n"
+     ]
+    }
+   ],
+   "source": [
+    "traced_k, traced_n = report_accuracy(final_model, 'VGG16 traced', dls)\n",
+    "trace_agree = count_agreement(final_learner.model, final_model, dls)\n",
+    "print(f'predictions identical on {trace_agree} of {traced_n} images')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fc5f0f7e117",
+   "metadata": {},
+   "source": [
+    "**3125/3925**, the same count as the model it was traced from, and the two answer identically on all 3925 validation images: the tracing changed the memory layout and the call path, not the arithmetic."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c63bf4a69d13",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "357156b642e5",
    "metadata": {},
    "source": [
     "## Summary\n",
     "\n",
-    "| Step | Tool | What it gives you |\n",
-    "|------|------|-------------------|\n",
-    "| Sparsify | `SparsifyCallback(sparsity, granularity, context, criteria, schedule)` | Weights zeroed during training, following the schedule |\n",
-    "| Prune | `Pruner(model, pruning_ratio, context, criteria)` | Filters removed, a structurally smaller model |\n",
-    "| Quantize | `Quantizer(backend='pt2e', method='static').quantize(model, calibration_dl)` | An INT8 graph, tagged with the precision that produced it |\n",
-    "| Export | `export_qdq(model, sample, path)` | An ONNX file whose Q/DQ pairs survived the export |\n",
-    "| Inspect | `qdq_stats(path)` | Node counts, per-channel count, zero-point audit |\n",
-    "| Verify | `verify_qdq(model, path, samples)` | Argmax agreement between the exported graph and PyTorch |\n",
-    "| Score | `ONNXModel(path)` | The exported file called like a PyTorch model |\n",
-    "| Cost | `tp.utils.count_ops_and_params` | MACs and parameters, at a given input size |\n",
+    "So to recap, we saw in this article how to use fasterai to: <br>\n",
+    "1. Make a student model learn from a teacher model (**Knowledge Distillation**) <br>\n",
+    "2. Make our network sparse (**Sparsifying**) <br>\n",
+    "3. Optionally physically remove the zero-filters (**Pruning**) <br>\n",
+    "4. Remove the batch norm layers (**Batch Normalization Folding**) <br>\n",
+    "5. Approximate our big fully-connected layers by smaller ones (**Fully-Connected Layers Factorization**) <br>\n",
+    "6. Quantize the model to reduce the precision of the weights (**Quantization**) <br>\n",
+    "7. Trace the result to take the Python overhead out of the inference (**Extra Acceleration**)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ee168f9c76d",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13c9fd103337",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "VGG16 after its ten epochs: 537.30 MB and 23.84ms per image (3183/3925 correct)\n",
+      "After the seven steps: 26.52 MB and 6.38ms per image (3125/3925 correct)\n",
+      "Compression ratio: 20.3x, speed ratio: 3.7x\n",
+      "1-minute load average at the timing cells: from 0.5 to 9.2\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"VGG16 after its ten epochs: {baseline_size/1e6:.2f} MB and {trained_ms:.2f}ms per image \"\n",
+    "      f\"({baseline_k}/{baseline_n} correct)\")\n",
+    "print(f\"After the seven steps: {accelerated_size/1e6:.2f} MB and {accelerated_ms:.2f}ms per image \"\n",
+    "      f\"({traced_k}/{traced_n} correct)\")\n",
+    "print(f\"Compression ratio: {baseline_size/accelerated_size:.1f}x, \"\n",
+    "      f\"speed ratio: {trained_ms/accelerated_ms:.1f}x\")\n",
+    "print(f\"1-minute load average at the timing cells: from {min(LOADS):.1f} to {max(LOADS):.1f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9e51ce83a94",
+   "metadata": {},
+   "source": [
+    "And we saw that by applying those, we could reduce our **VGG16** model from **537.30 MB** of parameters down to **26.52 MB** (**20.3x** compression) — that last figure written by `torch.jit.save`, where every other size on this page is a `torch.save` of the state dict — and also speed-up the inference from **23.84ms** to **6.38ms** (**3.7x** speed-up), single run, the reference being the trained **VGG16** and not the untrained one timed at the top. The accuracy went from 3183/3925 correct to 3125/3925 — the final model having had thirty-five epochs to the baseline's ten (see the scope below)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab23f8789166",
+   "metadata": {},
+   "source": [
+    "**Scope.** VGG16 trained from scratch on Imagenette at 128 pixels, 9469 training images and 3925 validation ones, one run of each step: ten epochs for the baseline, three for the pretrained VGG19 teacher, ten for the student, ten with the `SparsifyCallback`, five with the `PruneCallback`, five to recover from the factorization and five more with the `QuantizeCallback`. The baseline and the student are built and fitted under `set_seed(42, reproducible=True)`, so those two differ only in the callback; nothing else on the page is seeded. Every accuracy on this page is the whole validation set, printed as k/n. Every latency is a single image on the CPU of the box named above, ten warm-up passes then three timing repeats of fifty passes each, one run of the page; the recap prints the range of the 1-minute load average at those cells, 0.5 to 9.2."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "533b5a5b0c49",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77b0b80ffa22",
+   "metadata": {},
+   "source": [
+    ":::{.callout-note}\n",
     "\n",
-    "`sparsity` and `pruning_ratio` are fractions in [0, 1]. `criteria` and `schedule` take the objects\n",
-    "exported by `fasterai.core.criteria` and `fasterai.core.schedule`.\n",
+    "Please keep in mind that the techniques presented above are not magic 🧙‍♂️, so do not expect to see the same compression and speed-up everytime. What you can achieve highly depend on the architecture that you are using (some are already speed/parameter efficient by design) or the task it is doing (some datasets are so easy that you can remove almost all your network without seeing a drop in performance)\n",
     "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de6ee1625534",
+   "metadata": {},
+   "source": [
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7de96d9f5731",
+   "metadata": {},
+   "source": [
     "---\n",
     "\n",
     "## See Also\n",
     "\n",
-    "- [Sparsify Callback](sparse/sparsify_callback.html) - The sparsification step on its own\n",
-    "- [Prune Callback](prune/prune_callback.html) - Pruning inside the training loop instead of between fits\n",
-    "- [Deployable INT8 Export](quantize/deployable_export.html) - The precision grammar and the QDQ export in detail\n",
-    "- [Knowledge Distillation](distill/distill_callback.html) - Training a student model from a teacher\n",
-    "- [BatchNorm Folding](misc/bn_folding.html) - Folding BatchNorm layers into their convolutions\n",
-    "- [FC Decomposition](misc/fc_decomposer.html) - Factorizing fully-connected layers"
+    "- [Knowledge Distillation](distill/distill_callback.html) - The distillation callback, its losses and its feature-map variants\n",
+    "- [Sparsify Callback](sparse/sparsify_callback.html) - Sparsification on its own, granularity by granularity\n",
+    "- [Prune Callback](prune/prune_callback.html) - Removing the filters inside the training loop\n",
+    "- [BatchNorm Folding](misc/bn_folding.html) - Folding BatchNorm into the convolution ahead of it\n",
+    "- [FC Decomposition](misc/fc_decomposer.html) - Factorizing fully-connected layers with SVD\n",
+    "- [Quantize Callback](quantize/quantize_callback.html) - Quantization-aware training and its backends"
    ]
   }
  ],


### PR DESCRIPTION
Stacked on #82, the `BN_Folder` subnormal flush: the fold step of this page is what found that defect, and the page is measured on top of the fix.

## Why

The September rewrite of the walkthrough kept the page honest and lost the page: the deployment story, the seven techniques in compression order, the concept-then-API-then-example beat of every section, the size and speed after each step, the recap, and the author's voice. This restores that page, on the current API, under the tutorial contract.

## What changed against the original, and only that

- **API**: fractions instead of percentages, `PruneCallback(pruning_ratio, schedule, context, criteria)`, `FC_Decomposer`, `optimize_for_cpu(..., backend='trace')` in place of the deprecated alias, `QuantizeCallback(backend='x86')`.
- **Numbers**: every number in prose is printed by a cell, every accuracy carries k/n on the 3925 validation images, every latency carries the machine, the thread count and "single run", the ratios of the recap are computed by a cell, and the 0.00 MB / 0 parameters that closed the original is replaced by the traced artifact's own size. The one sentence the contract's vocabulary refused, "without any drop in accuracy", now shows the two counts.
- **Three of the four decisions**: VGG16 on Imagenette as the running example; no ONNX export section; size and speed from a torch-only helper, no fasterbench import; the Extra Acceleration section kept, since `torch.jit.save` gives its size honestly.
- **Comparisons the original made in passing, now controlled**: the distilled student and the vanilla VGG16 share the seed, the epochs and the learning rate, and the page reports the gap in images without attributing it; the 8-bit model's sentence names the five extra epochs it received; the recap says the final model had thirty-five epochs to the baseline's ten and that its size comes from a different serializer.

Everything else is the original's: the sections, the images, the callouts, the blockquotes, the spelling, "Snap !", "Yay ! Now we can talk !", and the wizard.

## What one run measured

| stage | size | CPU latency, batch 1, mean of three repeats | accuracy |
|---|---|---|---|
| VGG16 after its ten epochs | 537.30 MB | 23.84 ms (23.82–23.87) | 3183/3925 |
| sparsified, 50 % of filters | 537.30 MB | 24.56 ms (24.54–24.58) | 3154/3925 |
| pruned | 173.95 MB | 14.60 ms (14.58–14.62) | 3158/3925 |
| BatchNorm folded | 173.89 MB | 12.29 ms (12.29–12.30) | 3158/3925 |
| FC factorized, retrained | 104.98 MB | 10.93 ms (10.91–10.96) | 3060/3925 |
| quantized, 8-bit | 26.42 MB | 7.99 ms (7.33–9.29) | 3125/3925 |
| traced | 26.52 MB | 6.38 ms (6.36–6.41) | 3125/3925 |

Intel i9-14900KS, 24 threads, torch 2.9.1, one image at a time, ten warm-up passes and three repeats of fifty timed ones, one run; the page prints the 1-minute load at the timing cells (0.5 to 9.2, the notebook's own preceding GPU cells). 20.3x smaller and 3.7x faster than the trained ten-epoch VGG16, the final model having had thirty-five epochs; the traced model answers identically to the 8-bit one on all 3925 images. The distilled student and the vanilla VGG16, at the same seed and budget, differ by 17 images, which the page reports without attributing.

## The defect this page found

Before #82 the fold step measured five to ten times slower than the pruned model it came from, reproducibly. The cause was not on the page and the first draft explained it wrongly; the results reviewer traced it on the saved models to `BN_Folder` copying a subnormal BatchNorm `beta` into the folded bias of every channel the sparsifier had emptied. With the flush, the fold is faster than the pruned model it comes from (12.29 against 14.60 ms) and leaves the count of correct predictions unchanged; the page says nothing about subnormals.
